### PR TITLE
fix: Deploy monitoring-operator with prometus-adapter via V1 job hangs

### DIFF
--- a/charts/qubership-monitoring-operator/Chart.yaml
+++ b/charts/qubership-monitoring-operator/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.22
+version: 1.4.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/Chart.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/apiservice-custom-metrics.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/apiservice-custom-metrics.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/name: v1beta1.custom.metrics.k8s.io
     app.kubernetes.io/instance: v1beta1.custom.metrics.k8s.io
     {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
 spec:
   service:
     name: prometheus-adapter

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/apiservice-resource-metrics.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/apiservice-resource-metrics.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/name: v1beta1.metrics.k8s.io
     app.kubernetes.io/instance: v1beta1.metrics.k8s.io
     {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
 spec:
   service:
     name: prometheus-adapter


### PR DESCRIPTION
set APIService installment for Prometheus Adapter Operator in the last order