### PR TITLE
ci: configure dependabot k8s group with victoriamrtrics operator

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,7 @@ updates:
       patterns:
       - "k8s.io/*"
       - "github.com/prometheus-operator/prometheus-operator/*"
+      - "github.com/VictoriaMetrics/operator/*"
     go.opentelemetry.io:
       patterns:
       - "go.opentelemetry.io/*"


### PR DESCRIPTION
Victoriametrics-operator libs depends on k8s API, to allow build need to group the changes