### PR TITLE
docs: Add missing docs for cloud-events-exporter and json-exporter

### DIFF
--- a/docs/installation/components/README.md
+++ b/docs/installation/components/README.md
@@ -23,6 +23,8 @@ This section contains detailed configuration documentation for all monitoring co
 * **[Kube State Metrics](exporters/kube-state-metrics.md)** - Kubernetes object state metrics
 * **[Blackbox Exporter](exporters/blackbox-exporter.md)** - External endpoint probing
 * **[Cert Exporter](exporters/cert-exporter.md)** - TLS certificate monitoring
+* **[Cloud Events Exporter](exporters/cloud-events-exporter.md)** - Kubernetes events monitoring
+* **[JSON Exporter](exporters/json-exporter.md)** - JSON endpoint monitoring
 * **[Version Exporter](exporters/version-exporter.md)** - Version tracking
 * **[Network Latency Exporter](exporters/network-latency-exporter.md)** - Network latency measurements
 

--- a/docs/installation/components/exporters/cloud-events-exporter.md
+++ b/docs/installation/components/exporters/cloud-events-exporter.md
@@ -1,0 +1,202 @@
+# Cloud Events Exporter
+
+The Cloud Events Exporter monitors Kubernetes events and exposes them as Prometheus
+metrics, enabling monitoring and alerting on cluster events such as pod failures,
+scaling events, and other operational activities.
+
+## Overview
+
+Cloud Events Exporter collects Kubernetes events from specified namespaces and
+converts them into metrics that can be scraped by Prometheus. This enables
+monitoring teams to:
+
+- Track event patterns and trends
+- Alert on critical events (warnings, errors)  
+- Monitor cluster health through event analysis
+- Create dashboards showing event statistics
+
+The exporter supports filtering by event type, kind, namespace, and other
+attributes to reduce noise and focus on relevant events.
+
+## Configuration Parameters
+
+<!-- markdownlint-disable line-length -->
+| Field                                   | Description                                                                                                                                                                                                            | Scheme                                                                                                                       |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| install                                 | Allows to enable or disable deployment of cloud-events-exporter.                                                                                                                                                      | bool                                                                                                                         |
+| name                                    | A deployment name for cloud-events-exporter. Used in deployment name and labels.                                                                                                                                     | string                                                                                                                       |
+| image                                   | Docker image for cloud-events-exporter. If not specified, uses default image.                                                                                                                                        | string                                                                                                                       |
+| port                                    | Port to scrape cloud events metrics.                                                                                                                                                                                  | int                                                                                                                          |
+| namespaces                              | List of namespaces to monitor for events. Empty list monitors all namespaces.                                                                                                                                         | list[string]                                                                                                                 |
+| rbac.createClusterRole                  | Allow creating ClusterRole. If set to `false`, ClusterRole must be created manually.                                                                                                                                 | bool                                                                                                                         |
+| rbac.createClusterRoleBinding           | Allow creating ClusterRoleBinding. If set to `false`, ClusterRoleBinding must be created manually.                                                                                                                   | bool                                                                                                                         |
+| filtering                               | Event filtering configuration to include/exclude specific events.                                                                                                                                                     | object                                                                                                                       |
+| filtering.match                         | List of event patterns to include. Events matching these patterns will be exported as metrics.                                                                                                                        | list[object]                                                                                                                 |
+| filtering.match[N].type                 | Event type to match (e.g., "Warning", "Normal").                                                                                                                                                                      | string                                                                                                                       |
+| filtering.match[N].kind                 | Resource kind to match (e.g., "Pod", "Deployment").                                                                                                                                                                   | string                                                                                                                       |
+| filtering.match[N].reason               | Event reason to match.                                                                                                                                                                                                 | string                                                                                                                       |
+| filtering.match[N].message              | Event message pattern to match (supports regex).                                                                                                                                                                      | string                                                                                                                       |
+| filtering.match[N].namespace            | Namespace to match events from.                                                                                                                                                                                       | string                                                                                                                       |
+| filtering.match[N].reportingController  | Reporting controller to match.                                                                                                                                                                                         | string                                                                                                                       |
+| filtering.match[N].reportingInstance    | Reporting instance to match.                                                                                                                                                                                           | string                                                                                                                       |
+| filtering.exclude                       | List of event patterns to exclude. Events matching these patterns will NOT be exported as metrics.                                                                                                                    | list[object]                                                                                                                 |
+| filtering.exclude[N].type               | Event type to exclude (e.g., "Normal").                                                                                                                                                                               | string                                                                                                                       |
+| filtering.exclude[N].reason             | Event reason to exclude (supports regex, e.g., "Completed OR Pulled OR Started").                                                                                                                                          | string                                                                                                                       |
+| filtering.exclude[N].message            | Event message pattern to exclude (supports regex).                                                                                                                                                                    | string                                                                                                                       |
+| serviceMonitor                          | Service monitor configuration for scraping metrics.                                                                                                                                                                   | object                                                                                                                       |
+| serviceMonitor.install                  | Enables ServiceMonitor creation for automatic metrics scraping.                                                                                                                                                       | bool                                                                                                                         |
+| serviceMonitor.interval                 | Scraping interval for metrics collection.                                                                                                                                                                             | string                                                                                                                       |
+| serviceMonitor.scrapeTimeout            | Timeout for scraping metrics. Must be less than interval.                                                                                                                                                             | string                                                                                                                       |
+| serviceMonitor.metricRelabelings        | Metric relabeling rules applied to scraped metrics.                                                                                                                                                                   | list[object]                                                                                                                 |
+| serviceMonitor.relabelings              | Target relabeling rules applied before scraping.                                                                                                                                                                      | list[object]                                                                                                                 |
+| extraArgs                               | Additional arguments for cloud-events-exporter container.                                                                                                                                                             | list[string]                                                                                                                 |
+| extraEnvs                               | Additional environment variables for cloud-events-exporter container.                                                                                                                                                 | object                                                                                                                       |
+| resources                               | Resource requests and limits for the container.                                                                                                                                                                       | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core) |
+| securityContext                         | SecurityContext holds pod-level security attributes.                                                                                                                                                                 | [*v1.PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podsecuritycontext-v1-core)    |
+| nodeSelector                            | Defines which nodes the pods are scheduled on.                                                                                                                                                                       | map[string]string                                                                                                            |
+| tolerations                             | Tolerations allow the pods to schedule onto nodes with matching taints.                                                                                                                                              | []v1.Toleration                                                                                                              |
+| affinity                                | Pod scheduling constraints.                                                                                                                                                                                           | *v1.Affinity                                                                                                                 |
+| annotations                             | Annotations to be added to pods.                                                                                                                                                                                      | map[string]string                                                                                                            |
+| labels                                  | Labels to be added to pods.                                                                                                                                                                                           | map[string]string                                                                                                            |
+| priorityClassName                       | PriorityClassName assigned to the pods to prevent them from evicting.                                                                                                                                                | string                                                                                                                       |
+| serviceAccount.install                  | Specifies whether a ServiceAccount should be created.                                                                                                                                                                | bool                                                                                                                         |
+| serviceAccount.annotations              | Annotations for the ServiceAccount.                                                                                                                                                                                   | map[string]string                                                                                                            |
+| serviceAccount.labels                   | Labels for the ServiceAccount.                                                                                                                                                                                        | map[string]string                                                                                                            |
+<!-- markdownlint-enable line-length -->
+
+## Metrics
+
+The cloud-events-exporter exposes the following metrics:
+
+- `cloud_events_total{type, kind, reason, namespace, ...}` - Total count of events
+  by type, kind, reason, and namespace
+- `cloud_events_warning_total{...}` - Total count of warning events
+- `cloud_events_normal_total{...}` - Total count of normal events
+- `cloud_events_reporting_controller_warning_total{controller, ...}` - Warning
+  events by reporting controller
+- `cloud_events_reporting_controller_normal_total{controller, ...}` - Normal
+  events by reporting controller
+
+## Configuration Examples
+
+### Basic Configuration
+
+Enable cloud-events-exporter with default settings:
+
+```yaml
+cloudEventsExporter:
+  install: true
+  name: cloud-events-exporter
+  port: 9999
+  serviceMonitor:
+    install: true
+    interval: 30s
+    scrapeTimeout: 10s
+```
+
+### Monitor Specific Namespaces
+
+Monitor events only from specified namespaces:
+
+```yaml
+cloudEventsExporter:
+  install: true
+  namespaces:
+    - monitoring
+    - kube-system
+    - default
+```
+
+### Event Filtering
+
+Filter events to focus on warnings and exclude noisy normal events:
+
+```yaml
+cloudEventsExporter:
+  install: true
+  filtering:
+    match:
+      - type: "Warning"
+        kind: "Pod|Deployment"
+      - type: "Warning"
+        namespace: "production"
+    exclude:
+      - type: "Normal"
+        message: ".*image.*"
+      - reason: "Completed|Pulled|Started"
+```
+
+### Custom Resource Configuration
+
+Configure resource limits and scheduling preferences:
+
+```yaml
+cloudEventsExporter:
+  install: true
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  nodeSelector:
+    node-role.kubernetes.io/worker: "true"
+  tolerations:
+    - key: "monitoring"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+```
+
+## Grafana Dashboard
+
+The cloud-events-exporter includes a pre-built Grafana dashboard that provides:
+
+- Event trends by type (Warning/Normal)
+- Top events by namespace and object
+- Event breakdown by reporting controllers
+- Cluster vs namespace-scoped events
+- Event frequency over time
+
+The dashboard is automatically deployed when `install: true` is set.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No metrics appearing**
+   - Check that `install: true` is set
+   - Verify RBAC permissions for events access
+   - Check pod logs for connection errors
+
+2. **Too many metrics**
+   - Configure `filtering.exclude` to reduce noise
+   - Limit `namespaces` to specific ones
+   - Use metric relabeling in ServiceMonitor
+
+3. **Missing events**
+   - Check `filtering.match` configuration
+   - Verify namespace access permissions
+   - Review event retention in cluster
+
+### Debug Commands
+
+```bash
+# Check cloud-events-exporter pod status
+kubectl get pods -l app.kubernetes.io/component=cloud-events-exporter -n monitoring
+
+# View exporter logs
+kubectl logs -l app.kubernetes.io/component=cloud-events-exporter -n monitoring
+
+# Check metrics endpoint
+kubectl port-forward svc/cloud-events-exporter 9999:9999 -n monitoring
+curl http://localhost:9999/metrics
+```
+
+## Security Considerations
+
+- The exporter requires cluster-wide `get`, `list`, and `watch` permissions on events
+- Consider limiting namespace access by configuring `namespaces` parameter
+- Use security contexts to run with minimal privileges
+- Filter sensitive events that might contain confidential information

--- a/docs/installation/components/exporters/json-exporter.md
+++ b/docs/installation/components/exporters/json-exporter.md
@@ -1,0 +1,505 @@
+# JSON Exporter
+
+The JSON Exporter allows you to scrape arbitrary JSON endpoints and convert them
+into Prometheus metrics. This is useful for monitoring APIs, services that expose
+JSON metrics, or any system that provides structured data in JSON format.
+
+## Overview
+
+JSON Exporter provides a way to:
+
+- Extract metrics from JSON APIs and endpoints
+- Convert JSON data structures into Prometheus metrics
+- Monitor third-party services that don't natively support Prometheus format
+- Create custom metrics from REST APIs and web services
+- Track application status and business metrics exposed via JSON
+
+The exporter supports complex JSON path expressions, custom labels, and multiple
+target configurations.
+
+## Configuration Parameters
+
+<!-- markdownlint-disable line-length -->
+| Field                                   | Description                                                                                                                                                                                                            | Scheme                                                                                                                       |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| install                                 | Allows to enable or disable deployment of json-exporter.                                                                                                                                                              | bool                                                                                                                         |
+| name                                    | A name of the microservice to deploy with. Used in deployment name and labels.                                                                                                                                        | string                                                                                                                       |
+| image                                   | Docker image for json-exporter.                                                                                                                                                                                       | string                                                                                                                       |
+| imagePullPolicy                         | Image pull policy for json-exporter deployment.                                                                                                                                                                       | string                                                                                                                       |
+| imagePullSecrets                        | Reference to secrets for pulling images from private registries.                                                                                                                                                      | list[object]                                                                                                                 |
+| containerPort                           | Port number that the json-exporter container listens on.                                                                                                                                                              | int                                                                                                                          |
+| replicaCount                            | Number of json-exporter pods to create.                                                                                                                                                                               | int                                                                                                                          |
+| service                                 | Service configuration for json-exporter.                                                                                                                                                                              | object                                                                                                                       |
+| service.type                            | Type of Kubernetes service (ClusterIP, NodePort, LoadBalancer).                                                                                                                                                       | string                                                                                                                       |
+| service.port                            | Port number for the service.                                                                                                                                                                                          | int                                                                                                                          |
+| service.name                            | Port name used in the service.                                                                                                                                                                                        | string                                                                                                                       |
+| service.labels                          | Additional labels for the service.                                                                                                                                                                                    | map[string]string                                                                                                            |
+| serviceMonitor                          | ServiceMonitor configuration for metrics scraping.                                                                                                                                                                    | object                                                                                                                       |
+| serviceMonitor.enabled                  | Enable ServiceMonitor creation for automatic metrics scraping.                                                                                                                                                        | bool                                                                                                                         |
+| serviceMonitor.scheme                   | HTTP scheme to use for scraping (http/https).                                                                                                                                                                         | string                                                                                                                       |
+| serviceMonitor.defaults                 | Default values for all ServiceMonitors created by targets.                                                                                                                                                            | object                                                                                                                       |
+| serviceMonitor.defaults.interval        | Default scraping interval.                                                                                                                                                                                            | string                                                                                                                       |
+| serviceMonitor.defaults.scrapeTimeout   | Default scrape timeout.                                                                                                                                                                                               | string                                                                                                                       |
+| serviceMonitor.defaults.labels          | Default labels for ServiceMonitors.                                                                                                                                                                                   | map[string]string                                                                                                            |
+| serviceMonitor.defaults.additionalMetricsRelabels | Default metric relabeling rules.                                                                                                                                                                                  | map[string]string                                                                                                            |
+| serviceMonitor.targets                  | List of targets to scrape with json-exporter.                                                                                                                                                                         | list[object]                                                                                                                 |
+| serviceMonitor.targets[N].name          | Human readable name for the target.                                                                                                                                                                                   | string                                                                                                                       |
+| serviceMonitor.targets[N].url           | URL that json-exporter will scrape.                                                                                                                                                                                   | string                                                                                                                       |
+| serviceMonitor.targets[N].labels        | Additional labels for this target's ServiceMonitor.                                                                                                                                                                   | map[string]string                                                                                                            |
+| serviceMonitor.targets[N].interval      | Scraping interval for this target.                                                                                                                                                                                    | string                                                                                                                       |
+| serviceMonitor.targets[N].scrapeTimeout | Scrape timeout for this target.                                                                                                                                                                                       | string                                                                                                                       |
+| serviceMonitor.targets[N].module        | Name of the module from config to use for this target.                                                                                                                                                                | string                                                                                                                       |
+| serviceMonitor.targets[N].additionalMetricsRelabels | Additional metric relabeling rules for this target.                                                                                                                                                      | map[string]string                                                                                                            |
+| config                                  | Configuration of json-exporter modules and metrics extraction rules.                                                                                                                                                  | object                                                                                                                       |
+| config.modules                          | Map of module configurations for different scraping scenarios.                                                                                                                                                        | map[string]object                                                                                                            |
+| config.modules[name].metrics            | List of metrics to extract from JSON responses.                                                                                                                                                                       | list[object]                                                                                                                 |
+| config.modules[name].metrics[N].name    | Prometheus metric name.                                                                                                                                                                                               | string                                                                                                                       |
+| config.modules[name].metrics[N].path    | JSONPath expression to extract the value.                                                                                                                                                                             | string                                                                                                                       |
+| config.modules[name].metrics[N].help    | Metric description.                                                                                                                                                                                                    | string                                                                                                                       |
+| config.modules[name].metrics[N].type    | Metric type (gauge, counter, etc.).                                                                                                                                                                                   | string                                                                                                                       |
+| config.modules[name].metrics[N].labels  | Static and dynamic labels for the metric.                                                                                                                                                                             | map[string]string                                                                                                            |
+| config.modules[name].metrics[N].values  | For object-type metrics, map of value names to JSONPath expressions.                                                                                                                                                  | map[string]string                                                                                                            |
+| config.modules[name].headers            | HTTP headers to send with requests.                                                                                                                                                                                   | map[string]string                                                                                                            |
+| config.modules[name].body               | HTTP body configuration for POST requests.                                                                                                                                                                            | object                                                                                                                       |
+| config.modules[name].http_client_config | HTTP client configuration (TLS, auth, etc.).                                                                                                                                                                          | object                                                                                                                       |
+| resources                               | Resource requests and limits for the container.                                                                                                                                                                       | [v1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core) |
+| securityContext                         | Pod-level security context.                                                                                                                                                                                           | [*v1.PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podsecuritycontext-v1-core)    |
+| containerSecurityContext               | Container-level security context.                                                                                                                                                                                     | [*v1.SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core)         |
+| nodeSelector                            | Node selector for pod scheduling.                                                                                                                                                                                     | map[string]string                                                                                                            |
+| tolerations                             | Tolerations for pod scheduling.                                                                                                                                                                                       | []v1.Toleration                                                                                                              |
+| affinity                                | Affinity rules for pod scheduling.                                                                                                                                                                                    | *v1.Affinity                                                                                                                 |
+| annotations                             | Annotations to add to pods.                                                                                                                                                                                           | map[string]string                                                                                                            |
+| labels                                  | Labels to add to pods.                                                                                                                                                                                                | map[string]string                                                                                                            |
+| priorityClassName                       | Priority class name for pod scheduling.                                                                                                                                                                               | string                                                                                                                       |
+| serviceAccount                          | ServiceAccount configuration.                                                                                                                                                                                         | object                                                                                                                       |
+| serviceAccount.install                  | Whether to create a ServiceAccount.                                                                                                                                                                                   | bool                                                                                                                         |
+| serviceAccount.annotations              | Annotations for the ServiceAccount.                                                                                                                                                                                   | map[string]string                                                                                                            |
+| serviceAccount.name                     | Name of the ServiceAccount to use.                                                                                                                                                                                    | string                                                                                                                       |
+| additionalVolumes                       | Additional volumes to mount.                                                                                                                                                                                           | list[object]                                                                                                                 |
+| additionalVolumeMounts                  | Additional volume mounts for the container.                                                                                                                                                                           | list[object]                                                                                                                 |
+<!-- markdownlint-enable line-length -->
+
+## Endpoints
+
+The json-exporter provides two main endpoints:
+
+- `/metrics` - Self-monitoring metrics
+- `/probe` - Probe endpoint for scraping JSON targets
+
+## Configuration Examples
+
+### Basic Configuration
+
+Enable json-exporter with basic setup:
+
+```yaml
+jsonExporter:
+  install: true
+  name: json-exporter
+  containerPort: 7979
+  service:
+    port: 7979
+    name: http
+  serviceMonitor:
+    enabled: true
+```
+
+### Simple JSON API Monitoring
+
+Monitor a simple JSON API endpoint:
+
+```yaml
+jsonExporter:
+  install: true
+  name: json-exporter
+  
+  # Configure module for API monitoring
+  config:
+    modules:
+      default:
+        metrics:
+          - name: api_status
+            path: "{ .status }"
+            help: API status indicator
+            labels:
+              service: "my-api"
+          - name: api_response_time
+            path: "{ .response_time_ms }"
+            help: API response time in milliseconds
+            type: gauge
+        headers:
+          User-Agent: "json-exporter/1.0"
+  
+  # Configure targets to scrape
+  serviceMonitor:
+    enabled: true
+    targets:
+      - name: api-health
+        url: "http://my-api.example.com/health"
+        interval: 30s
+        scrapeTimeout: 10s
+```
+
+### Complex JSON Structure
+
+Extract metrics from complex JSON with arrays and nested objects:
+
+```yaml
+jsonExporter:
+  install: true
+  config:
+    modules:
+      complex_api:
+        metrics:
+          # Extract global counter
+          - name: total_requests
+            path: "{ .stats.total_requests }"
+            help: Total number of requests
+            type: counter
+            
+          # Extract metrics from array of services
+          - name: service_status
+            type: object
+            help: Status of individual services
+            path: '{.services[*]}'
+            labels:
+              service_name: '{.name}'
+              version: '{.version}'
+              environment: "production"  # static label
+            values:
+              status: '{.status == "healthy" ? 1 : 0}'
+              uptime_seconds: '{.uptime}'
+              
+          # Extract timestamped metric
+          - name: last_update
+            path: "{ .last_update }"
+            epochTimestamp: "{ .timestamp }"
+            help: Last update timestamp
+  
+  serviceMonitor:
+    enabled: true
+    targets:
+      - name: complex-service
+        url: "https://api.example.com/status"
+        module: complex_api
+        interval: 60s
+```
+
+### POST Request with Body
+
+Configure json-exporter to send POST requests with custom body:
+
+```yaml
+jsonExporter:
+  install: true
+  config:
+    modules:
+      post_api:
+        metrics:
+          - name: query_result_count
+            path: "{ .data.count }"
+            help: Number of results from API query
+        headers:
+          Content-Type: "application/json"
+          X-API-Key: "secret-key"
+        body:
+          content: |
+            {
+              "query": "SELECT COUNT(*) FROM users WHERE active = true",
+              "format": "json"
+            }
+  
+  serviceMonitor:
+    enabled: true
+    targets:
+      - name: database-stats
+        url: "https://api.example.com/query"
+        module: post_api
+        interval: 300s  # 5 minutes
+```
+
+### Authentication and TLS
+
+Configure authentication and TLS settings:
+
+```yaml
+jsonExporter:
+  install: true
+  config:
+    modules:
+      secure_api:
+        metrics:
+          - name: secure_metric
+            path: "{ .value }"
+            help: Metric from secure endpoint
+        http_client_config:
+          tls_config:
+            insecure_skip_verify: false
+            ca_file: /etc/ssl/certs/ca.pem
+          basic_auth:
+            username: monitoring_user
+            password_file: /etc/secrets/password
+            
+  # Mount secrets for authentication
+  additionalVolumes:
+    - name: auth-secret
+      secret:
+        secretName: json-exporter-auth
+    - name: ca-cert
+      configMap:
+        name: ca-certificates
+        
+  additionalVolumeMounts:
+    - name: auth-secret
+      mountPath: /etc/secrets
+      readOnly: true
+    - name: ca-cert
+      mountPath: /etc/ssl/certs
+      readOnly: true
+  
+  serviceMonitor:
+    enabled: true
+    targets:
+      - name: secure-api
+        url: "https://secure-api.example.com/metrics"
+        module: secure_api
+```
+
+### Template-based Body
+
+Use Go templates for dynamic request bodies:
+
+```yaml
+jsonExporter:
+  install: true
+  config:
+    modules:
+      templated_api:
+        metrics:
+          - name: dynamic_query_result
+            path: "{ .result }"
+            help: Result from templated query
+        body:
+          content: |
+            {
+              "timestamp": "{{ now.Unix }}",
+              "query_id": "{{ .query_id | default `default_query` }}",
+              "duration": "{{ duration `300` }}"
+            }
+          templatize: true
+  
+  serviceMonitor:
+    enabled: true
+    targets:
+      - name: templated-endpoint
+        url: "https://api.example.com/templated?query_id=metrics_query"
+        module: templated_api
+```
+
+### Production Configuration
+
+Complete production-ready configuration:
+
+```yaml
+jsonExporter:
+  install: true
+  name: json-exporter
+  image: prometheuscommunity/json-exporter:v0.7.0
+  imagePullPolicy: IfNotPresent
+  replicaCount: 2
+  
+  # Service configuration
+  service:
+    type: ClusterIP
+    port: 7979
+    name: http
+  
+  # Resource management
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  
+  # Security context
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    fsGroup: 65534
+  
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+  
+  # Scheduling
+  nodeSelector:
+    node-role.kubernetes.io/worker: "true"
+    
+  tolerations:
+    - key: "monitoring"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+  
+  # ServiceAccount
+  serviceAccount:
+    install: true
+    name: json-exporter
+    annotations:
+      description: "ServiceAccount for JSON Exporter"
+  
+  # Modules configuration
+  config:
+    modules:
+      api_monitoring:
+        metrics:
+          - name: api_health_status
+            path: "{ .health }"
+            help: API health status (1=healthy, 0=unhealthy)
+            labels:
+              service: '{.service_name}'
+              version: '{.version}'
+          - name: api_response_time_seconds
+            path: "{ .response_time / 1000 }"
+            help: API response time in seconds
+            type: gauge
+      
+      business_metrics:
+        metrics:
+          - name: active_users_total
+            path: "{ .metrics.active_users }"
+            help: Total number of active users
+            type: gauge
+          - name: revenue_total
+            path: "{ .metrics.revenue }"
+            help: Total revenue in cents
+            type: counter
+        headers:
+          Authorization: "Bearer {{ .token }}"
+  
+  # ServiceMonitor with multiple targets
+  serviceMonitor:
+    enabled: true
+    scheme: http
+    defaults:
+      interval: 30s
+      scrapeTimeout: 10s
+      labels:
+        monitoring: "json-exporter"
+    targets:
+      # API health monitoring
+      - name: api-health
+        url: "http://my-api.svc.cluster.local:8080/health"
+        module: api_monitoring
+        interval: 15s
+        
+      # Business metrics
+      - name: business-metrics
+        url: "http://analytics.svc.cluster.local:8080/metrics"
+        module: business_metrics
+        interval: 60s
+        additionalMetricsRelabels:
+          environment: "production"
+  
+  # Pod labels and annotations
+  labels:
+    component: monitoring
+    tier: exporters
+    
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "7979"
+```
+
+## JSONPath Examples
+
+Common JSONPath expressions for extracting data:
+
+```json
+{
+  "status": "ok",
+  "data": {
+    "count": 42,
+    "items": [
+      {"name": "item1", "value": 10},
+      {"name": "item2", "value": 20}
+    ]
+  },
+  "meta": {
+    "timestamp": 1640995200
+  }
+}
+```
+
+<!-- markdownlint-disable line-length -->
+| JSONPath | Description | Result |
+|----------|-------------|---------|
+| `{ .status }` | Root level field | "ok" |
+| `{ .data.count }` | Nested field | 42 |
+| `{ .data.items[0].value }` | Array element field | 10 |
+| `{ .data.items[*].value }` | All array elements | [10, 20] |
+| `{ .data.items[?(@.value > 15)].name }` | Filtered array | ["item2"] |
+| `{ .meta.timestamp }` | Timestamp field | 1640995200 |
+<!-- markdownlint-enable line-length -->
+
+## Troubleshooting
+
+### Common Issues
+
+1. **No metrics from targets**
+   - Check target URL accessibility from the pod
+   - Verify module configuration syntax
+   - Check JSONPath expressions with test data
+
+2. **Authentication failures**
+   - Verify credentials are mounted correctly
+   - Check HTTP client configuration
+   - Review target service authentication requirements
+
+3. **Invalid JSON responses**
+   - Check if target returns valid JSON
+   - Verify content-type headers
+   - Use curl to test endpoints manually
+
+### Debug Commands
+
+```bash
+# Check json-exporter pod status
+kubectl get pods -l app.kubernetes.io/component=json-exporter -n monitoring
+
+# View exporter logs
+kubectl logs -l app.kubernetes.io/component=json-exporter -n monitoring
+
+# Test metrics endpoint
+kubectl port-forward svc/json-exporter 7979:7979 -n monitoring
+curl http://localhost:7979/metrics
+
+# Test probe endpoint manually
+curl "http://localhost:7979/probe?module=default&target=http://example.com/api"
+
+# Check configuration
+kubectl get configmap json-exporter -o yaml -n monitoring
+```
+
+## Security Considerations
+
+- Store sensitive credentials in Kubernetes secrets
+- Use RBAC to limit access to json-exporter configuration
+- Implement network policies to restrict outbound connections
+- Use TLS for external API communications
+- Regularly rotate API keys and passwords
+- Avoid exposing sensitive data in metric labels
+
+## Performance Tips
+
+- Use appropriate scraping intervals based on data freshness needs
+- Limit the number of metrics extracted from complex JSON structures
+- Implement timeouts for slow endpoints
+- Monitor json-exporter resource usage
+- Use metric relabeling to reduce cardinality
+- Cache responses when possible using HTTP client configuration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ edit_uri: edit/main/docs/
 theme:
   name: material
   language: en
-  
+
   palette:
     # Dark theme by default
     - media: "(prefers-color-scheme)"
@@ -21,7 +21,7 @@ theme:
       toggle:
         icon: material/brightness-auto
         name: Switch to light mode
-    
+
     # Light theme option
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -30,7 +30,7 @@ theme:
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    
+
     # Dark theme option (default)
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
@@ -128,10 +128,10 @@ plugins:
   - search:
       separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
 
-# Navigation 
+# Navigation
 nav:
   - Home: README.md
-  
+
   # Installation - "I want to install the system"
   - Installation:
       - Installation Guide: installation/README.md
@@ -148,14 +148,16 @@ nav:
           - Profiling: installation/components/pprof.md
           - Exporters:
               - Blackbox Exporter: installation/components/exporters/blackbox-exporter.md
+              - Cert Exporter: installation/components/exporters/cert-exporter.md
+              - Cloud Events Exporter: installation/components/exporters/cloud-events-exporter.md
               - Cloudwatch Exporter: installation/components/exporters/cloudwatch-exporter.md
+              - JSON Exporter: installation/components/exporters/json-exporter.md
+              - Kube State Metrics: installation/components/exporters/kube-state-metrics.md
+              - Network Latency Exporter: installation/components/exporters/network-latency-exporter.md
+              - Node Exporter: installation/components/exporters/node-exporter.md
               - Promitor Agent Scraper: installation/components/exporters/promitor-agent-scraper.md
               - Stackdriver Exporter: installation/components/exporters/stackdriver-exporter.md
-              - Cert Exporter: installation/components/exporters/cert-exporter.md
-              - Network Latency Exporter: installation/components/exporters/network-latency-exporter.md
               - Version Exporter: installation/components/exporters/version-exporter.md
-              - Kube State Metrics: installation/components/exporters/kube-state-metrics.md
-              - Node Exporter: installation/components/exporters/node-exporter.md
           - VictoriaMetrics Stack:
               - Overview: installation/components/victoriametrics-stack/victoriametrics.md
               - VMAgent: installation/components/victoriametrics-stack/vmagent.md
@@ -172,7 +174,7 @@ nav:
               - AlertManager: installation/components/prometheus-stack/alertmanager.md
           - Grafana Stack:
               - Grafana: installation/components/grafana-stack/grafana.md
-  
+
   # Architecture & Components - "I want to understand how the system works"
   - Architecture & Components:
     - Architecture Overview: architecture.md
@@ -181,7 +183,7 @@ nav:
       - Platform Monitoring: api/platform-monitoring.md
       - Prometheus Adapter: api/prometheus-adapter.md
       - Custom Scale Metric Rule: api/custom-scale-metric-rule.md
-  
+
   # Configuration - "I want to configure the system"
   - Configuration:
     - Basic Configuration: configuration.md
@@ -199,19 +201,19 @@ nav:
       - Default Dashboards:
           - Overview: defaults/dashboards/home-dashboard.md
           - Overall Platform Health: defaults/dashboards/overall-platform-health.md
-          
+
           # Alerting & Monitoring
           - Alerting:
               - Alertmanager Overview: defaults/dashboards/alertmanager-overview.md
               - Alerts Overview: defaults/dashboards/alerts-overview.md
-          
+
           # Kubernetes Cluster Monitoring
           - Kubernetes Core:
               - API Server: defaults/dashboards/kubernetes-apiserver.md
               - Cluster Overview: defaults/dashboards/kubernetes-cluster-overview.md
               - ETCD: defaults/dashboards/kubernetes-etcd.md
               - Kubelet: defaults/dashboards/kubernetes-kubelet.md
-          
+
           # Kubernetes Resources
           - Kubernetes Resources:
               - Namespace Resources: defaults/dashboards/kubernetes-namespace-resources.md
@@ -222,7 +224,7 @@ nav:
               - Pods Distribution by Node: defaults/dashboards/kubernetes-pods-distribution-by-node.md
               - Pods Distribution by Zone: defaults/dashboards/kubernetes-pods-distribution-by-zone.md
               - HA Services: defaults/dashboards/ha-services.md
-          
+
           # Ingress & Networking
           - Networking:
               - NGINX Ingress Controller: defaults/dashboards/ingress-nginx-controller.md
@@ -233,13 +235,13 @@ nav:
               - Network Latency Overview: defaults/dashboards/network-latency-exporter-overview.md
               - Network Latency Details: defaults/dashboards/network-latency-exporter-details.md
               - CoreDNS: defaults/dashboards/core-dns-dashboard.md
-          
+
           # Application Monitoring
           - Applications:
               - JVM Processes: defaults/dashboards/jvm-processes.md
               - Go Processes: defaults/dashboards/govm-processes.md
               - Kafka Java Clients: defaults/dashboards/dashboard-kafka-java-clients.md
-          
+
           # System & Infrastructure
           - Infrastructure:
               - Node Details: defaults/dashboards/node-details.md
@@ -247,7 +249,7 @@ nav:
               - Certificates: defaults/dashboards/cert-exporter.md
               - Version Exporter: defaults/dashboards/version-exporter.md
               - Backup Daemon: defaults/dashboards/dashboard-backup-daemon.md
-          
+
           # Monitoring Tools
           - Monitoring Stack:
               - Prometheus Self-Monitoring: defaults/dashboards/prometheus-self-monitoring.md
@@ -256,14 +258,14 @@ nav:
               - Grafana Overview: defaults/dashboards/grafana-overview.md
               - Blackbox Exporter: defaults/dashboards/blackbox-exporter.md
               - Graphite Adapter: defaults/dashboards/graphite-adapter-dashboard-for-grafana.md
-          
+
           # VictoriaMetrics
           - VictoriaMetrics:
               - VMSingle: defaults/dashboards/victoriametrics-vmsingle.md
               - VMAgent: defaults/dashboards/victoriametrics-vmagent.md
               - VMAlert: defaults/dashboards/victoriametrics-vmalert.md
               - VM Operator: defaults/dashboards/victoriametrics-vmoperator.md
-          
+
           # OpenShift (Platform-specific)
           - OpenShift:
               - API Server: defaults/dashboards/openshift-apiserver.md
@@ -294,7 +296,7 @@ nav:
       - IBM Netcool: integration/ibm-netcool.md
     - Integration Examples:
       - Custom Endpoints: examples/custom-resources/custom-endpoint/README.md
-  
+
   # Security - "I want to secure the system"
   - Security:
     - Authentication:
@@ -306,7 +308,7 @@ nav:
       - Route/Ingress TLS: monitoring-configuration/route-ingress-tls.md
     - Security Examples:
       - Service with TLS: examples/custom-resources/service-with-tls/README.md
-  
+
   # Operations - "The system is running, I want to maintain it"
   - Operations:
     - Troubleshooting: troubleshooting.md


### PR DESCRIPTION
After moving to MkDocs some chapters was missed. 
Restoring  it as separate files.