### PR TITLE
fix: switched kube-state-metrics to endpointslices

### DIFF
--- a/controllers/kubestatemetrics/assets/cluster-role.yaml
+++ b/controllers/kubestatemetrics/assets/cluster-role.yaml
@@ -22,6 +22,7 @@ rules:
       - persistentvolumes
       - namespaces
       - endpoints
+      - endpointslices
     verbs:
       - 'list'
       - 'watch'
@@ -117,3 +118,12 @@ rules:
     verbs:
       - 'list'
       - 'watch'
+
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch

--- a/controllers/utils/vars.go
+++ b/controllers/utils/vars.go
@@ -33,7 +33,7 @@ const (
 	VmAuthOAuthProxyServiceName = "vmauth-oauth2-proxy"
 	VmAuthServicePort           = 8427
 
-	ScrapeResources = "configmaps,cronjobs,daemonsets,deployments,endpoints,jobs,limitranges,persistentvolumeclaims,poddisruptionbudgets,namespaces,nodes,pods,persistentvolumes,replicasets,replicationcontrollers,resourcequotas,services,statefulsets"
+	ScrapeResources = "configmaps,cronjobs,daemonsets,deployments,endpointslices,jobs,limitranges,persistentvolumeclaims,poddisruptionbudgets,namespaces,nodes,pods,persistentvolumes,replicasets,replicationcontrollers,resourcequotas,services,statefulsets"
 
 	VmComponentName       = "k8s"
 	VmSingleComponentName = "vmsingle"


### PR DESCRIPTION
switched kube-state-metrics to endpointslices