### PR TITLE
chore(ci): change conditions to run link checker to validate it only after changes

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -2,23 +2,35 @@
 name: Link Checker
 
 on:
-  push: null
-  repository_dispatch: null
-  workflow_dispatch: null
   pull_request:
-    branches: [main]
+    branches:
+      - main
     types:
-      [opened, reopened, synchronize]
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - 'docs/**'
+      - '*.md'
+  push:
+    branches:
+      - main
+    paths:
+        - 'docs/**'
+        - '*.md'
+  workflow_dispatch: null
+
 permissions:
   contents: read
+
 jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: restore-cache
         with:
           path: .lycheecache
@@ -27,7 +39,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 #v2.6.1
         with:
           args: >-
             './**/*.md'


### PR DESCRIPTION
# What does this PR do?

Change the `on` conditions to run the `Link checker` only for cases when the author changed:

* documents in `/docs` directory
* any of the markdown docs in the repository root