### PR TITLE
fix: EndpointSlice API group was changed

### DIFF
--- a/charts/qubership-monitoring-operator/templates/operator/clusterrole.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/clusterrole.yaml
@@ -54,7 +54,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - endpointslices
       - namespaces
       - nodes
       - nodes/metrics
@@ -63,6 +62,15 @@ rules:
       - persistentvolumes
       - replicationcontrollers
       - resourcequotas
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+      - 'update'
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
     verbs:
       - 'get'
       - 'list'

--- a/controllers/kubestatemetrics/assets/cluster-role.yaml
+++ b/controllers/kubestatemetrics/assets/cluster-role.yaml
@@ -22,7 +22,6 @@ rules:
       - persistentvolumes
       - namespaces
       - endpoints
-      - endpointslices
     verbs:
       - 'list'
       - 'watch'


### PR DESCRIPTION
task: https://github.com/Netcracker/qubership-monitoring-operator/issues/191

Endpointslices API group  was changed from "" to "discovery.k8s.io"