### PR TITLE
fix: add app.kubernetes.io labels to Helm charts (base)

### DIFF
--- a/charts/qubership-monitoring-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/templates/_helpers.tpl
@@ -1,6 +1,28 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Resource labels: name, app.kubernetes.io/name, component, part-of, managed-by, managed-by-operator.
+Optional: managedByOperator (override), processedByOperator (for CRs only).
+Usage: {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $name "component" $component) | nindent 4 }}
+       For CRs: add "processedByOperator" "prometheus-adapter-operator"
+       For workloads (Deployment, StatefulSet, DaemonSet), add instance, version, technology inline.
+*/}}
+{{- define "monitoring.resourceLabels" -}}
+{{- $ctx := .ctx -}}
+{{- $name := .name -}}
+{{- $component := .component -}}
+name: {{ $name }}
+app.kubernetes.io/name: {{ $name }}
+app.kubernetes.io/component: {{ $component }}
+app.kubernetes.io/part-of: {{ (index $ctx.Values "global" | default dict).partOf | default "monitoring" }}
+app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
+app.kubernetes.io/managed-by-operator: {{ .managedByOperator | default (index $ctx.Values "global" | default dict).managedByOperator | default "monitoring-operator" }}
+{{- if .processedByOperator }}
+app.kubernetes.io/processed-by-operator: {{ .processedByOperator }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Expand the name of the chart. This is suffixed with -alertmanager, which means subtract 13 from longest 63 available
 */}}
 {{- define "monitoring.name" -}}

--- a/charts/qubership-monitoring-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/templates/_helpers.tpl
@@ -14,7 +14,7 @@ Usage: {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $name "compo
 name: {{ $name }}
 app.kubernetes.io/name: {{ $name }}
 app.kubernetes.io/component: {{ $component }}
-app.kubernetes.io/part-of: {{ (index $ctx.Values "global" | default dict).partOf | default "monitoring" }}
+app.kubernetes.io/part-of: monitoring
 app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
 {{- if .processedByOperator }}
 app.kubernetes.io/processed-by-operator: {{ .processedByOperator }}

--- a/charts/qubership-monitoring-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/templates/_helpers.tpl
@@ -1,8 +1,8 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Resource labels: name, app.kubernetes.io/name, component, part-of, managed-by, managed-by-operator.
-Optional: managedByOperator (override), processedByOperator (for CRs only).
+Resource labels: name, app.kubernetes.io/name, component, part-of, managed-by.
+Optional: processedByOperator (for CRs only).
 Usage: {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $name "component" $component) | nindent 4 }}
        For CRs: add "processedByOperator" "prometheus-adapter-operator"
        For workloads (Deployment, StatefulSet, DaemonSet), add instance, version, technology inline.
@@ -16,7 +16,6 @@ app.kubernetes.io/name: {{ $name }}
 app.kubernetes.io/component: {{ $component }}
 app.kubernetes.io/part-of: {{ (index $ctx.Values "global" | default dict).partOf | default "monitoring" }}
 app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
-app.kubernetes.io/managed-by-operator: {{ .managedByOperator | default (index $ctx.Values "global" | default dict).managedByOperator | default "monitoring-operator" }}
 {{- if .processedByOperator }}
 app.kubernetes.io/processed-by-operator: {{ .processedByOperator }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/templates/integration-tests/clusterrole.yml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/clusterrole.yml
@@ -4,11 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "integrationTests.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "integrationTests.rbac.fullname" . }}
-    app.kubernetes.io/component: platform-monitoring-tests
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "integrationTests.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "integrationTests.rbac.fullname" .) "component" "platform-monitoring-tests") | nindent 4 }}
 rules:
   - apiGroups:
       - "integreatly.org"

--- a/charts/qubership-monitoring-operator/templates/integration-tests/clusterrolebinding.yml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/clusterrolebinding.yml
@@ -4,11 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "integrationTests.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "integrationTests.rbac.fullname" . }}
-    app.kubernetes.io/component: platform-monitoring-tests
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "integrationTests.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "integrationTests.rbac.fullname" .) "component" "platform-monitoring-tests") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.integrationTests.name }}

--- a/charts/qubership-monitoring-operator/templates/integration-tests/deployment.yml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/deployment.yml
@@ -4,11 +4,10 @@ apiVersion: apps/v1
 metadata:
   name: {{ .Values.integrationTests.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.integrationTests.name }}
-    app.kubernetes.io/component: platform-monitoring-tests
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.integrationTests.name "component" "platform-monitoring-tests") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
     app.kubernetes.io/version: {{ template "integrationTests.version" . }}
+    app.kubernetes.io/technology: go
     {{- if .Values.integrationTests.labels }}
       {{- toYaml .Values.integrationTests.labels | nindent 4 }}
     {{- end }}
@@ -26,13 +25,10 @@ spec:
   template:
     metadata:
       labels:
-        name: {{ .Values.integrationTests.name }}
-        app.kubernetes.io/name: {{ .Values.integrationTests.name }}
-        app.kubernetes.io/component: platform-monitoring-tests
-        app.kubernetes.io/part-of: monitoring
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.integrationTests.name "component" "platform-monitoring-tests") | nindent 8 }}
         app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
         app.kubernetes.io/version: {{ template "integrationTests.version" . }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.integrationTests.labels }}
           {{- toYaml .Values.integrationTests.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/templates/integration-tests/role-int-tests.yml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/role-int-tests.yml
@@ -4,11 +4,7 @@ kind: Role
 metadata:
   name: {{ .Values.integrationTests.name }}-int-tests
   labels:
-    app.kubernetes.io/name: {{ .Values.integrationTests.name }}-int-tests
-    app.kubernetes.io/component: platform-monitoring-tests
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "integrationTests.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-int-tests" .Values.integrationTests.name) "component" "platform-monitoring-tests") | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/qubership-monitoring-operator/templates/integration-tests/role-write-status.yml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/role-write-status.yml
@@ -5,11 +5,7 @@ kind: Role
 metadata:
   name: {{ .Values.integrationTests.name }}-write-status
   labels:
-    app.kubernetes.io/name: {{ .Values.integrationTests.name }}-write-status
-    app.kubernetes.io/component: platform-monitoring-tests
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "integrationTests.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-write-status" .Values.integrationTests.name) "component" "platform-monitoring-tests") | nindent 4 }}
 rules:
 - apiGroups:
   - {{ template "integrationTests.apigroup_custom_resource" . }}

--- a/charts/qubership-monitoring-operator/templates/integration-tests/rolebinding-int-tests.yml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/rolebinding-int-tests.yml
@@ -4,11 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.integrationTests.name }}-int-tests
   labels:
-    app.kubernetes.io/name: {{ .Values.integrationTests.name }}
-    app.kubernetes.io/component: platform-monitoring-tests
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "integrationTests.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-int-tests" .Values.integrationTests.name) "component" "platform-monitoring-tests") | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.integrationTests.name }}

--- a/charts/qubership-monitoring-operator/templates/integration-tests/rolebinding-write-status.yml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/rolebinding-write-status.yml
@@ -5,11 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.integrationTests.name }}-write-status
   labels:
-    app.kubernetes.io/name: {{ .Values.integrationTests.name }}-write-status
-    app.kubernetes.io/component: platform-monitoring-tests
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "integrationTests.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-write-status" .Values.integrationTests.name) "component" "platform-monitoring-tests") | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.integrationTests.name }}

--- a/charts/qubership-monitoring-operator/templates/integration-tests/serviceaccount.yml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/serviceaccount.yml
@@ -4,9 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.integrationTests.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.integrationTests.name }}
-    app.kubernetes.io/component: platform-monitoring-tests
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "integrationTests.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.integrationTests.name "component" "platform-monitoring-tests") | nindent 4 }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/templates/integration-tests/test-config.yaml
+++ b/charts/qubership-monitoring-operator/templates/integration-tests/test-config.yaml
@@ -7,7 +7,7 @@ kind: ConfigMap
 metadata:
   name: tests-config
   labels:
-    app: monitoring-tests
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "tests-config" "component" "platform-monitoring-tests") | nindent 4 }}
 data:
   {{- if ne (include "monitoredImages.wrapper" .) "DEFAULT" }}
     dd_images: {{ include "monitoring.monitoredImages" . | indent 2 | quote }}

--- a/charts/qubership-monitoring-operator/templates/oauth2-configs/secret-extra-vars-grafana.yaml
+++ b/charts/qubership-monitoring-operator/templates/oauth2-configs/secret-extra-vars-grafana.yaml
@@ -5,11 +5,7 @@ kind: Secret
 metadata:
   name: grafana-extra-vars-secret
   labels:
-    app.kubernetes.io/name: grafana-extra-vars-secret
-    app.kubernetes.io/instance: {{ cat "grafana-extra-vars-secret-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: grafana
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "grafana-extra-vars-secret" "component" "grafana") | nindent 4 }}
 type: Opaque
 stringData:
 {{- if .Values.auth}}

--- a/charts/qubership-monitoring-operator/templates/oauth2-configs/secret-oauth2-proxy-config.yaml
+++ b/charts/qubership-monitoring-operator/templates/oauth2-configs/secret-oauth2-proxy-config.yaml
@@ -5,12 +5,7 @@ kind: Secret
 metadata:
   name: oauth2-proxy-config
   labels:
-    app.kubernetes.io/name: oauth2-proxy-config
-    app.kubernetes.io/component: oauth2-proxy
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: {{ cat "oauth2-proxy-config-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "oauth2-proxy-config" "component" "oauth2-proxy") | nindent 4 }}
 stringData:
   oauth2-proxy.cfg: |-
     cookie_secret = "Z0lKZ64IEMCv8XQM9smEDw=="

--- a/charts/qubership-monitoring-operator/templates/oauth2-configs/service-alertmanager.yaml
+++ b/charts/qubership-monitoring-operator/templates/oauth2-configs/service-alertmanager.yaml
@@ -6,12 +6,7 @@ kind: Service
 metadata:
   name: alertmanager-oauth2-proxy
   labels:
-    app.kubernetes.io/name: alertmanager-oauth2-proxy
-    app.kubernetes.io/component: oauth2-proxy
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: {{ cat "alertmanager-oauth2-proxy-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "alertmanager-oauth2-proxy" "component" "oauth2-proxy") | nindent 4 }}
 spec:
   clusterIP: None
   ports:

--- a/charts/qubership-monitoring-operator/templates/oauth2-configs/service-prometheus.yaml
+++ b/charts/qubership-monitoring-operator/templates/oauth2-configs/service-prometheus.yaml
@@ -6,12 +6,7 @@ kind: Service
 metadata:
   name: prometheus-oauth2-proxy
   labels:
-    app.kubernetes.io/name: prometheus-oauth2-proxy
-    app.kubernetes.io/component: oauth2-proxy
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/instance: {{ cat "prometheus-oauth2-proxy-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-oauth2-proxy" "component" "oauth2-proxy") | nindent 4 }}
 spec:
   clusterIP: None
   ports:

--- a/charts/qubership-monitoring-operator/templates/operator/clusterrole.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/clusterrole.yaml
@@ -4,11 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "monitoring.operator.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "monitoring.operator.rbac.fullname" . }}
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "monitoring.operator.rbac.fullname" .) "component" "monitoring-operator") | nindent 4 }}
 rules:
   - apiGroups:
       - "rbac.authorization.k8s.io"

--- a/charts/qubership-monitoring-operator/templates/operator/clusterrolebinding.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/clusterrolebinding.yaml
@@ -4,11 +4,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: {{ template "monitoring.operator.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "monitoring.operator.rbac.fullname" . }}
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "monitoring.operator.rbac.fullname" .) "component" "monitoring-operator") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.monitoringOperator.serviceAccount.name }}

--- a/charts/qubership-monitoring-operator/templates/operator/deployment.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/deployment.yaml
@@ -3,11 +3,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.monitoringOperator.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.monitoringOperator.name }}
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.monitoringOperator.name "component" "monitoring-operator") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
     app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
+    app.kubernetes.io/technology: go
     {{- if .Values.monitoringOperator.labels }}
       {{- toYaml .Values.monitoringOperator.labels | nindent 4 }}
     {{- end }}
@@ -23,13 +22,10 @@ spec:
   template:
     metadata:
       labels:
-        name: {{ .Values.monitoringOperator.name }}
-        app.kubernetes.io/name: {{ .Values.monitoringOperator.name }}
-        app.kubernetes.io/component: monitoring-operator
-        app.kubernetes.io/part-of: monitoring
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.monitoringOperator.name "component" "monitoring-operator") | nindent 8 }}
         app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
         app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.monitoringOperator.labels }}
           {{- toYaml .Values.monitoringOperator.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/templates/operator/platformmonitoring.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/platformmonitoring.yaml
@@ -3,9 +3,7 @@ kind: PlatformMonitoring
 metadata:
   name: platformmonitoring
   labels:
-    app.kubernetes.io/name: platformmonitoring
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "platformmonitoring" "component" "monitoring-operator" "processedByOperator" (.Values.monitoringOperator.name | default "monitoring-operator")) | nindent 4 }}
     app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
     app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
 spec:

--- a/charts/qubership-monitoring-operator/templates/operator/podmonitor.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/podmonitor.yaml
@@ -4,11 +4,7 @@ kind: PodMonitor
 metadata:
   name: monitoring-operator
   labels:
-    app.kubernetes.io/name: monitoring-operator
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "monitoring-operator" "component" "monitoring-operator" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   podMetricsEndpoints:
   - interval: {{ .Values.monitoringOperator.podMonitor.interval }}

--- a/charts/qubership-monitoring-operator/templates/operator/role.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/role.yaml
@@ -5,11 +5,7 @@ kind: Role
 metadata:
   name: {{ template "monitoring.operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "monitoring.operator.fullname" . }}
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "monitoring.operator.fullname" .) "component" "monitoring-operator") | nindent 4 }}
 rules:
   - apiGroups:
       - "rbac.authorization.k8s.io"

--- a/charts/qubership-monitoring-operator/templates/operator/rolebinding.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/rolebinding.yaml
@@ -5,11 +5,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: {{ template "monitoring.operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "monitoring.operator.fullname" . }}
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "monitoring.operator.fullname" .) "component" "monitoring-operator") | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.monitoringOperator.serviceAccount.name }}

--- a/charts/qubership-monitoring-operator/templates/operator/service.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/service.yaml
@@ -4,11 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "monitoring.name" . }}
   labels:
-    app.kubernetes.io/name: {{ template "monitoring.name" . }}
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "monitoring.name" .) "component" "monitoring-operator") | nindent 4 }}
     {{- if .Values.monitoringOperator.pprof.service.labels }}
       {{ toYaml .Values.monitoringOperator.pprof.service.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/templates/operator/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/serviceaccount.yaml
@@ -4,9 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.monitoringOperator.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.monitoringOperator.serviceAccount.name }}
-    app.kubernetes.io/component: monitoring-operator
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "monitoring.instance" . }}
-    app.kubernetes.io/version: {{ template "monitoring.operator.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.monitoringOperator.serviceAccount.name "component" "monitoring-operator") | nindent 4 }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/values.yaml
+++ b/charts/qubership-monitoring-operator/values.yaml
@@ -9,9 +9,6 @@ nameOverride: ""
 fullnameOverride: ""
 
 global:
-  # Common labels for subcharts (app.kubernetes.io/part-of)
-  partOf: monitoring
-
   # Indicates if monitoring-operator has permissions to deploy ClusterRole and
   # ClusterRoleBinding resources.
   # If set to `true` deploy all resources. Otherwise, deploy only Role and RoleBinding

--- a/charts/qubership-monitoring-operator/values.yaml
+++ b/charts/qubership-monitoring-operator/values.yaml
@@ -9,6 +9,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 global:
+  # Common labels for subcharts (app.kubernetes.io/part-of)
+  partOf: monitoring
+
   # Indicates if monitoring-operator has permissions to deploy ClusterRole and
   # ClusterRoleBinding resources.
   # If set to `true` deploy all resources. Otherwise, deploy only Role and RoleBinding


### PR DESCRIPTION
- Add resourceLabels helper
- Apply labels to operator, oauth2-configs, integration-tests templates
- Add processedByOperator to PlatformMonitoring and PodMonitor CRs
