### PR TITLE
fix: add app.kubernetes.io labels to exporter subcharts

### DIFF
--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/configmap.yaml
@@ -4,12 +4,7 @@ kind: {{ if .Values.secretConfig -}} Secret {{- else -}} ConfigMap {{- end }}
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "blackbox-exporter") | nindent 4 }}
 {{ if .Values.secretConfig -}}
 stringData: {{- else -}} data: {{- end }}
   blackbox.yaml: |

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/daemonset.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/daemonset.yaml
@@ -4,12 +4,11 @@ kind: DaemonSet
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "blackbox-exporter") | nindent 4 }}
     {{- $image := include "blackboxExporter.image" . }}
+    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
     app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
     {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -25,12 +24,10 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "blackbox-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: blackbox-exporter
-        app.kubernetes.io/part-of: monitoring
         app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
         {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/dashboard.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/dashboard.yaml
@@ -4,12 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/deployment.yaml
@@ -4,12 +4,11 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "blackbox-exporter") | nindent 4 }}
     {{- $image := include "blackboxExporter.image" . }}
+    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
     app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
       {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -25,12 +24,10 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "blackbox-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: blackbox-exporter
-        app.kubernetes.io/part-of: monitoring
         app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
           {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/service.yaml
@@ -4,12 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "blackbox-exporter") | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/serviceaccount.yaml
@@ -4,10 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "blackbox-exporter") | nindent 4 }}
 {{- end -}}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor-self.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor-self.yaml
@@ -3,12 +3,7 @@ kind: ServiceMonitor
 metadata:
   name: blackbox-exporter
   labels:
-    app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/instance: {{ cat "blackbox-exporter-self-service-monitor-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "blackbox-exporter" "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval }}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor.yaml
@@ -6,12 +6,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ $.Values.name }}-{{ .name }}
   labels:
-    app.kubernetes.io/name: {{ $.Values.name }}-{{ .name }}
-    app.kubernetes.io/instance: {{ cat $.Values.name "-" .name "-" $.Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" $ }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" (printf "%s-%s" $.Values.name .name) "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   endpoints:
   - port: http

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/clusterrole.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/clusterrole.yaml
@@ -6,11 +6,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "certExporter.rbac.fullname" $ }}
   labels:
-    app.kubernetes.io/name: {{ template "certExporter.rbac.fullname" $ }}
-    app.kubernetes.io/component: cert-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
-    app.kubernetes.io/version: {{ template "certExporter.version" $ }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" (include "certExporter.rbac.fullname" $) "component" "cert-exporter") | nindent 4 }}
 rules:
   {{- if or (and .certsInFiles .certsInFiles.enabled) (and .certsInKubeconfig .certsInKubeconfig.enabled) }}
   {{- if $.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/clusterrolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/clusterrolebinding.yaml
@@ -4,11 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "certExporter.rbac.fullname" $ }}
   labels:
-    app.kubernetes.io/name: {{ template "certExporter.rbac.fullname" $ }}
-    app.kubernetes.io/component: cert-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
-    app.kubernetes.io/version: {{ template "certExporter.version" $ }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" (include "certExporter.rbac.fullname" $) "component" "cert-exporter") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.name }}

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/daemonset.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/daemonset.yaml
@@ -5,11 +5,10 @@ kind: DaemonSet
 metadata:
   name: {{ .name }}
   labels:
-    app.kubernetes.io/name: {{ .name }}
-    app.kubernetes.io/component: cert-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" .name "component" "cert-exporter") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
     app.kubernetes.io/version: {{ template "certExporter.version" $ }}
+    app.kubernetes.io/technology: go
     {{- if .daemonset.labels }}
       {{- toYaml .daemonset.labels | nindent 4 }}
     {{- end }}
@@ -25,12 +24,10 @@ spec:
     metadata:
       labels:
         app: {{ .name }}
-        app.kubernetes.io/name: {{ .name }}
-        app.kubernetes.io/component: cert-exporter
-        app.kubernetes.io/part-of: monitoring
+        {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" .name "component" "cert-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
         app.kubernetes.io/version: {{ template "certExporter.version" $ }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .daemonset.labels }}
           {{- toYaml .daemonset.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/dashboard.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/dashboard.yaml
@@ -4,11 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "certExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/deployment.yaml
@@ -5,11 +5,10 @@ kind: Deployment
 metadata:
   name: {{ .name }}
   labels:
-    app.kubernetes.io/name: {{ .name }}
-    app.kubernetes.io/component: cert-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" .name "component" "cert-exporter") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
     app.kubernetes.io/version: {{ template "certExporter.version" $ }}
+    app.kubernetes.io/technology: go
     {{- if .deployment.labels }}
       {{- toYaml .deployment.labels | nindent 4 }}
     {{- end }}
@@ -25,12 +24,10 @@ spec:
     metadata:
       labels:
         app: {{ .name }}
-        app.kubernetes.io/name: {{ .name }}
-        app.kubernetes.io/component: cert-exporter
-        app.kubernetes.io/part-of: monitoring
+        {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" .name "component" "cert-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
         app.kubernetes.io/version: {{ template "certExporter.version" $ }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .deployment.labels }}
           {{- toYaml .deployment.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/podsecuritypolicy.yaml
@@ -7,11 +7,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "certExporter.rbac.fullname" $ }}
   labels:
-    app.kubernetes.io/name: {{ template "certExporter.rbac.fullname" $ }}
-    app.kubernetes.io/component: cert-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
-    app.kubernetes.io/version: {{ template "certExporter.version" $ }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" (include "certExporter.rbac.fullname" $) "component" "cert-exporter") | nindent 4 }}
 spec:
   privileged: false
   # Allow core volume types.

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/prometheusrule.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/prometheusrule.yaml
@@ -6,11 +6,7 @@ kind: PrometheusRule
 metadata:
   name: {{ .name }}-prometheus-rules
   labels:
-    app.kubernetes.io/name: {{ .name }}-prometheus-rules
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
-    app.kubernetes.io/version: {{ template "certExporter.version" $ }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" (printf "%s-prometheus-rules" .name) "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   groups:
   - name: {{ .name }}

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/securitycontextconstraints.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/securitycontextconstraints.yaml
@@ -7,11 +7,7 @@ kind: SecurityContextConstraints
 metadata:
   name: {{ template "certExporter.rbac.fullname" $ }}
   labels:
-    app.kubernetes.io/name: {{ template "certExporter.rbac.fullname" $ }}
-    app.kubernetes.io/component: cert-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" $ }}
-    app.kubernetes.io/version: {{ template "certExporter.version" $ }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" (include "certExporter.rbac.fullname" $) "component" "cert-exporter") | nindent 4 }}
 priority: 0
 users: []
 groups: []

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/service.yaml
@@ -6,11 +6,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cert-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "certExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cert-exporter") | nindent 4 }}
 spec:
   ports:
     - name: metrics

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/serviceaccount.yaml
@@ -4,9 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cert-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "certExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cert-exporter") | nindent 4 }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/cert-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/cert-exporter/templates/servicemonitor.yaml
@@ -4,11 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "certExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "certExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval }}

--- a/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/cluster-role-binding.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/cluster-role-binding.yaml
@@ -4,11 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cloudEventsExporter.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "cloudEventsExporter.fullname" . }}
-    app.kubernetes.io/component: cloud-events-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "cloudEventsExporter.fullname" .) "component" "cloud-events-exporter") | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/cluster-role.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/cluster-role.yaml
@@ -4,11 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "cloudEventsExporter.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "cloudEventsExporter.fullname" . }}
-    app.kubernetes.io/component: cloud-events-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "cloudEventsExporter.fullname" .) "component" "cloud-events-exporter") | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/configmap.yaml
@@ -4,11 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cloud-events-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cloud-events-exporter") | nindent 4 }}
 data:
 {{- if .Values.filtering }}
   filtering.yaml: |-

--- a/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/dashboard-cloud-events-exporter.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/dashboard-cloud-events-exporter.yaml
@@ -4,11 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ template "cloudEventsExporter.fullname" . }}
-    app.kubernetes.io/component: cloud-events-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "cloudEventsExporter.fullname" .) "component" "cloud-events-exporter" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/deployment.yaml
@@ -4,11 +4,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ template "cloudEventsExporter.fullname" . }}
-    app.kubernetes.io/component: cloud-events-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "cloudEventsExporter.fullname" .) "component" "cloud-events-exporter") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
     app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
       {{ toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -24,12 +23,10 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ template "cloudEventsExporter.fullname" . }}
-        app.kubernetes.io/component: cloud-events-exporter
-        app.kubernetes.io/part-of: monitoring
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "cloudEventsExporter.fullname" .) "component" "cloud-events-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
         app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
         {{ toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/service-account.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/service-account.yaml
@@ -4,11 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cloud-events-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cloud-events-exporter") | nindent 4 }}
     {{- if .Values.serviceAccount.labels }}
     {{ toYaml .Values.serviceAccount.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/service-monitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/service-monitor.yaml
@@ -4,11 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cloud-events-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cloud-events-exporter" "processedByOperator" "prometheus-operator") | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}
     {{ toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloud-events-exporter/templates/service.yaml
@@ -4,11 +4,7 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ template "cloudEventsExporter.fullname" . }}
-    app.kubernetes.io/component: cloud-events-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "cloudEventsExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "cloudEventsExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "cloudEventsExporter.fullname" .) "component" "cloud-events-exporter") | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/clusterrole.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/clusterrole.yaml
@@ -4,9 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "cloudwatch-exporter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "cloudwatch-exporter.rbac.fullname" . }}
-    app.kubernetes.io/component: cloudwatch-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "cloudwatch-exporter.rbac.fullname" .) "component" "cloudwatch-exporter") | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["secrets","configmaps"]

--- a/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/clusterrolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/clusterrolebinding.yaml
@@ -4,9 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "cloudwatch-exporter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "cloudwatch-exporter.rbac.fullname" . }}
-    app.kubernetes.io/component: cloudwatch-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "cloudwatch-exporter.rbac.fullname" .) "component" "cloudwatch-exporter") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}

--- a/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/configmap.yaml
@@ -4,9 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cloudwatch-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cloudwatch-exporter") | nindent 4 }}
 data:
   config.yml: |
     {{ tpl .Values.config . | nindent 4 }}

--- a/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/deployment.yaml
@@ -4,11 +4,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cloudwatch-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cloudwatch-exporter") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "cloudwatch-exporter.instance" . }}
     app.kubernetes.io/version: {{ template "cloudwatch-exporter.version" . }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
       {{ toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -25,12 +24,10 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
-        app.kubernetes.io/component: cloudwatch-exporter
-        app.kubernetes.io/part-of: monitoring
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cloudwatch-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ template "cloudwatch-exporter.instance" . }}
         app.kubernetes.io/version: {{ template "cloudwatch-exporter.version" . }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
           {{ toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/secrets.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/secrets.yaml
@@ -4,9 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cloudwatch-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cloudwatch-exporter") | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.aws.aws_access_key_id }}

--- a/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/service.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ .Values.name }}
   annotations: {{- toYaml .Values.service.annotations | nindent 4 }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: cloudwatch-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "cloudwatch-exporter") | nindent 4 }}
     {{- if .Values.service.labels }}
       {{ toYaml .Values.service.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/serviceaccount.yaml
@@ -5,9 +5,7 @@ automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountT
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
-    app.kubernetes.io/component: cloudwatch-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.serviceAccount.name "component" "cloudwatch-exporter") | nindent 4 }}
   annotations:
   {{- if .Values.serviceAccount.annotations }}
     {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}

--- a/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/cloudwatch-exporter/templates/servicemonitor.yaml
@@ -4,9 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}
       {{ toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/common-dashboards/templates/dashboard-backup-daemon.yaml
+++ b/charts/qubership-monitoring-operator/charts/common-dashboards/templates/dashboard-backup-daemon.yaml
@@ -4,11 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: backup-daemon
   labels:
-    app.kubernetes.io/name: backup-daemon
-    app.kubernetes.io/instance: {{ cat "backup-daemon-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "backup-daemon" "component" "monitoring" "managedByOperator" "monitoring-operator" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/common-dashboards/templates/dashboard-kafka-java-clients.yaml
+++ b/charts/qubership-monitoring-operator/charts/common-dashboards/templates/dashboard-kafka-java-clients.yaml
@@ -4,11 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: kafka-java-clients
   labels:
-    app.kubernetes.io/name: kafka-java-clients
-    app.kubernetes.io/instance: {{ cat "kafka-java-clients-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "kafka-java-clients" "component" "monitoring" "managedByOperator" "monitoring-operator" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   name: kafka-java-clients-dashboard.json
   json: >

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/_helpers.tpl
@@ -13,29 +13,6 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Common labels
-*/}}
-{{- define "goldpinger.labels" -}}
-helm.sh/chart: {{ include "goldpinger.chart" . }}
-{{ include "goldpinger.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/name: {{ default .Values.rbac.name (include "goldpinger.name" .) }}
-app.kubernetes.io/component: goldpinger-exporter
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: monitoring
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "goldpinger.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "goldpinger.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{/*
 Create the name of the service account to use
 */}}
 {{- define "goldpinger.serviceAccountName" -}}

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/clusterrole.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.name }}-clusterrole
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-clusterrole" .Values.name) "component" "goldpinger-exporter") | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/clusterrolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.name }}-clusterrolebinding
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-clusterrolebinding" .Values.name) "component" "goldpinger-exporter") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "goldpinger.serviceAccountName" . }}

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.name }}-zap
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-zap" .Values.name) "component" "goldpinger-exporter") | nindent 4 }}
 data:
   zap.json: {{ .Values.goldpinger.zapConfig | toJson }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/daemonset.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/daemonset.yaml
@@ -1,10 +1,15 @@
 {{- if .Values.install }}
+{{- $image := include "goldpinger.image" . }}
+{{- $instance := printf "%s-%s" .Values.name .Release.Namespace | trunc 63 | trimSuffix "-" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Values.name }}
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "goldpinger-exporter") | nindent 4 }}
+    app.kubernetes.io/instance: {{ $instance }}
+    app.kubernetes.io/version: {{ splitList ":" $image | last | quote }}
+    app.kubernetes.io/technology: go
 spec:
   {{- with .Values.updateStrategy }}
   updateStrategy:
@@ -12,7 +17,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "goldpinger.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ .Values.name | quote }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -20,7 +25,10 @@ spec:
         {{ toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "goldpinger.selectorLabels" . | nindent 8 }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "goldpinger-exporter") | nindent 8 }}
+        app.kubernetes.io/instance: {{ $instance }}
+        app.kubernetes.io/version: {{ splitList ":" $image | last | quote }}
+        app.kubernetes.io/technology: go
       {{- with .Values.podLabels }}
       {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/dashboard.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/dashboard.yaml
@@ -4,7 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >    
     {

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/ingress.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/ingress.yaml
@@ -17,7 +17,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $fullName "component" "goldpinger-exporter") | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/prometheusrule.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/prometheusrule.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   {{- with .Values.prometheusRule.rules }}
   groups:

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/role.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.name }}-pod-security-policy
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-pod-security-policy" .Values.name) "component" "goldpinger-exporter") | nindent 4 }}
 rules:
 {{- if not .Values.rbac.clusterscoped }}
 - apiGroups: [""]

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/rolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.name }}-pod-security-policy
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-pod-security-policy" .Values.name) "component" "goldpinger-exporter") | nindent 4 }}
 roleRef:
   kind: Role
   name: {{ .Values.name }}-pod-security-policy

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "goldpinger-exporter") | nindent 4 }}
     {{- with .Values.service.labels }}
     {{ toYaml . | indent 4 }}
     {{- end }}
@@ -20,7 +20,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "goldpinger.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ .Values.name | quote }}
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/serviceaccount.yaml
@@ -4,5 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ include "goldpinger.serviceAccountName" . }}
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "goldpinger.serviceAccountName" .) "component" "goldpinger-exporter") | nindent 4 }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/goldpinger-exporter/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Values.serviceMonitor.namespace }}
   {{- end }}
   labels:
-    {{- include "goldpinger.labels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
     {{- range $key, $value := .Values.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -28,5 +28,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "goldpinger.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ .Values.name | quote }}
 {{- end -}}

--- a/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/configmap.yaml
@@ -4,12 +4,7 @@ kind: ConfigMap
 metadata:
   name: graphite-config
   labels:
-    app.kubernetes.io/name: graphite-config
-    app.kubernetes.io/instance: {{ cat "graphite-config-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: graphite-remote-adapter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "graphiteRemoteAdapter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "graphite-config" "component" "graphite-remote-adapter") | nindent 4 }}
 data:
   {{- if .Values.additionalGraphiteConfig }}
   additionalGraphiteConfig.yaml: |-

--- a/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/dashboard.yaml
+++ b/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/dashboard.yaml
@@ -4,12 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: graphite-remote-adapter-dashboard
   labels:
-    app.kubernetes.io/name: graphite-remote-adapter-dashboard
-    app.kubernetes.io/instance: {{ cat "graphite-remote-adapter-dashboard-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "graphiteRemoteAdapter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "graphite-remote-adapter-dashboard" "component" "monitoring" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/deployment.yaml
@@ -4,12 +4,11 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: graphite-remote-adapter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "graphite-remote-adapter") | nindent 4 }}
     {{- $image := include "graphiteRemoteAdapter.image" . }}
+    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
     app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
       {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -26,12 +25,10 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "graphite-remote-adapter") | nindent 8 }}
         app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: graphite-remote-adapter
-        app.kubernetes.io/part-of: monitoring
         app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
           {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/service.yaml
@@ -4,12 +4,7 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: graphite-remote-adapter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "graphiteRemoteAdapter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "graphite-remote-adapter") | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/serviceaccount.yaml
@@ -4,10 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: graphite-remote-adapter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "graphiteRemoteAdapter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "graphite-remote-adapter") | nindent 4 }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/graphite-remote-adapter/templates/servicemonitor.yaml
@@ -4,12 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat $.Release.Namespace "-" .Values.name "-" $.Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "graphiteRemoteAdapter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   endpoints:
     - interval: 30s

--- a/charts/qubership-monitoring-operator/charts/json-exporter/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/json-exporter/templates/configmap.yaml
@@ -4,12 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: json-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "jsonExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "json-exporter") | nindent 4 }}
 data:
   allow-snippet-annotations: "false"
   {{- if .Values.config }}

--- a/charts/qubership-monitoring-operator/charts/json-exporter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/json-exporter/templates/deployment.yaml
@@ -4,12 +4,11 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: json-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "json-exporter") | nindent 4 }}
     {{- $image := include "jsonExporter.image" . }}
+    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
     app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
       {{ toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -26,12 +25,10 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "json-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: json-exporter
-        app.kubernetes.io/part-of: monitoring
         app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
           {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/json-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/json-exporter/templates/service.yaml
@@ -4,14 +4,9 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: json-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "jsonExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "json-exporter") | nindent 4 }}
     {{- if .Values.service.labels }}
-      {{ toYaml .Values.service.labels | indent 4 }}
+      {{ toYaml .Values.service.labels | nindent 4 }}
     {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/qubership-monitoring-operator/charts/json-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/json-exporter/templates/serviceaccount.yaml
@@ -4,14 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: json-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "jsonExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "json-exporter") | nindent 4 }}
     {{- if .Values.service.labels }}
-      {{ toYaml .Values.service.labels | indent 4 }}
+      {{ toYaml .Values.service.labels | nindent 4 }}
     {{- end }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:

--- a/charts/qubership-monitoring-operator/charts/json-exporter/templates/servicemonitor-self.yaml
+++ b/charts/qubership-monitoring-operator/charts/json-exporter/templates/servicemonitor-self.yaml
@@ -3,12 +3,7 @@ kind: ServiceMonitor
 metadata:
   name: json-exporter-self-service-monitor
   labels:
-    app.kubernetes.io/name: json-exporter-self-service-monitor
-    app.kubernetes.io/instance: {{ cat "json-exporter-self-service-monitor-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "jsonExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "json-exporter-self-service-monitor" "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval | default .Values.serviceMonitor.defaults.interval }}

--- a/charts/qubership-monitoring-operator/charts/json-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/json-exporter/templates/servicemonitor.yaml
@@ -6,12 +6,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ $.Values.name }}-{{ .name }}
   labels:
-    app.kubernetes.io/name: {{ $.Values.name }}-{{ .name }}
-    app.kubernetes.io/instance: {{ cat $.Release.Namespace "-" $.Values.name "-" .name "-" $.Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "jsonExporter.image" $ }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" (printf "%s-%s" $.Values.name .name) "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   endpoints:
   - port: {{ $.Values.service.name }}

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/clusterrole.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/clusterrole.yaml
@@ -4,11 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "networkLatencyExporter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "networkLatencyExporter.rbac.fullname" . }}
-    app.kubernetes.io/component: network-latency-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "networkLatencyExporter.rbac.fullname" .) "component" "network-latency-exporter") | nindent 4 }}
 rules:
   {{- if $.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
   - apiGroups:

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/clusterrolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/clusterrolebinding.yaml
@@ -4,11 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "networkLatencyExporter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "networkLatencyExporter.rbac.fullname" . }}
-    app.kubernetes.io/component: network-latency-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "networkLatencyExporter.rbac.fullname" .) "component" "network-latency-exporter") | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/daemonset.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/daemonset.yaml
@@ -4,11 +4,10 @@ kind: DaemonSet
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: network-latency-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "network-latency-exporter") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
     app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    app.kubernetes.io/technology: go
     {{- if .Values.additionalLabels }}
       {{- toYaml .Values.additionalLabels | nindent 4 }}
     {{- end }}
@@ -30,12 +29,10 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Values.name }}
-        app.kubernetes.io/component: network-latency-exporter
-        app.kubernetes.io/part-of: monitoring
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "network-latency-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
         app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
           {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/dashboard-details.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/dashboard-details.yaml
@@ -4,11 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}-details
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}-details
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-details" .Values.name) "component" "monitoring" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/dashboard-overview.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/dashboard-overview.yaml
@@ -4,11 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}-overview
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}-overview
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-overview" .Values.name) "component" "monitoring" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/podsecuritypolicy.yaml
@@ -5,11 +5,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "networkLatencyExporter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "networkLatencyExporter.rbac.fullname" . }}
-    app.kubernetes.io/component: network-latency-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "networkLatencyExporter.rbac.fullname" .) "component" "network-latency-exporter") | nindent 4 }}
 spec:
   privileged: {{ default false .Values.rbac.privileged }}
   hostPID: false

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/service.yaml
@@ -4,12 +4,7 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   labels:
-    name: {{ .Values.name }}
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: network-latency-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "network-latency-exporter") | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/serviceaccount.yaml
@@ -4,10 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    name: {{ .Values.serviceAccount.name }}
-    app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
-    app.kubernetes.io/component: network-latency-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.serviceAccount.name "component" "network-latency-exporter") | nindent 4 }}
 {{- end -}}

--- a/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/network-latency-exporter/templates/servicemonitor.yaml
@@ -4,11 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "networkLatencyExporter.instance" . }}
-    app.kubernetes.io/version: {{ template "networkLatencyExporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval | default "30s" }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/configmap.yaml
@@ -7,12 +7,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-resource-discovery
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentResourceDiscovery.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-resource-discovery") | nindent 4 }}
     {{- if .Values.labels }}
     {{ toYaml .Values.labels | nindent 8 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -4,12 +4,11 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-resource-discovery
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-resource-discovery") | nindent 4 }}
     {{- $image := include "promitor.agentResourceDiscovery.image" . }}
+    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
     app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    app.kubernetes.io/technology: csharp
     {{- if .Values.labels }}
     {{ toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -26,12 +25,10 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-resource-discovery") | nindent 8 }}
         app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: promitor-agent-resource-discovery
-        app.kubernetes.io/part-of: monitoring
         app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: csharp
         {{- if .Values.labels }}
           {{ toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/secret.yaml
@@ -4,12 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Values.secrets.secretName }}
   labels:
-    app.kubernetes.io/name: {{ .Values.secrets.secretName }}
-    app.kubernetes.io/instance: {{ cat .Values.secrets.secretName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-resource-discovery
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentResourceDiscovery.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.secrets.secretName "component" "promitor-agent-resource-discovery") | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.azureAuthentication.identity.key }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/service.yaml
@@ -4,12 +4,7 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-resource-discovery
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentResourceDiscovery.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-resource-discovery") | nindent 4 }}
     {{- if .Values.service.labels }}
       {{ toYaml .Values.service.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/serviceaccount.yaml
@@ -5,12 +5,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
-    app.kubernetes.io/instance: {{ cat .Values.serviceAccount.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-resource-discovery
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentResourceDiscovery.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.serviceAccount.name "component" "promitor-agent-resource-discovery") | nindent 4 }}
     {{- if .Values.serviceAccount.labels }}
       {{ toYaml .Values.serviceAccount.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-resource-discovery/templates/servicemonitor.yaml
@@ -4,11 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Release.Namespace "-" .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentResourceDiscovery.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-resource-discovery" "processedByOperator" "prometheus-operator") | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}
       {{ toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/configmap.yaml
@@ -5,12 +5,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-scraper
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentScraper.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-scraper") | nindent 4 }}
 data:
   runtime.yaml: |-
       server:

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/deployment.yaml
@@ -5,12 +5,11 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-scraper
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-scraper") | nindent 4 }}
     {{- $image := include "promitor.agentScraper.image" . }}
+    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
     app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    app.kubernetes.io/technology: csharp
     {{- if .Values.labels }}
       {{ toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -27,12 +26,10 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-scraper") | nindent 8 }}
         app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: promitor-agent-scraper
-        app.kubernetes.io/part-of: monitoring
         app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: csharp
         {{- if .Values.labels }}
           {{ toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/secret.yaml
@@ -4,12 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Values.secrets.secretName }}
   labels:
-    app.kubernetes.io/name: {{ .Values.secrets.secretName }}
-    app.kubernetes.io/instance: {{ cat .Values.secrets.secretName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-scraper
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentScraper.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.secrets.secretName "component" "promitor-agent-scraper") | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.azureAuthentication.identity.key}}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/service.yaml
@@ -4,12 +4,7 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-scraper
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentScraper.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-scraper") | nindent 4 }}
     {{- if .Values.service.labels }}
       {{ toYaml .Values.service.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/serviceaccount.yaml
@@ -5,12 +5,7 @@ automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountT
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
-    app.kubernetes.io/instance: {{ cat .Values.serviceAccount.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promitor-agent-scraper
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentScraper.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.serviceAccount.name "component" "promitor-agent-scraper") | nindent 4 }}
     {{- if .Values.serviceAccount.labels }}
       {{ toYaml .Values.serviceAccount.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/promitor-agent-scraper/templates/servicemonitor.yaml
@@ -4,11 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Release.Namespace "-" .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promitor.agentScraper.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promitor-agent-scraper" "processedByOperator" "prometheus-operator") | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}
       {{ toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/promxy/templates/dashboard.yaml
+++ b/charts/qubership-monitoring-operator/charts/promxy/templates/dashboard.yaml
@@ -4,12 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promxy.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/promxy/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/promxy/templates/deployment.yaml
@@ -4,14 +4,13 @@ apiVersion: apps/v1
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promxy
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promxy") | nindent 4 }}
     {{- $image := include "promxy.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    app.kubernetes.io/instance: {{ printf "%s-%s" .Values.name .Release.Namespace | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/version: {{ splitList ":" $image | last | quote }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
-      {{- toYaml .Values.labels | nindent 4 }}
+    {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
   {{- if .Values.annotations }}
   annotations:
@@ -26,14 +25,12 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
-        app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: promxy
-        app.kubernetes.io/part-of: monitoring
-        app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promxy") | nindent 8 }}
+        app.kubernetes.io/instance: {{ printf "%s-%s" .Values.name .Release.Namespace | trunc 63 | trimSuffix "-" }}
+        app.kubernetes.io/version: {{ splitList ":" $image | last | quote }}
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
-          {{- toYaml .Values.labels | nindent 8 }}
+        {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}
       {{- if .Values.annotations }}
       annotations:

--- a/charts/qubership-monitoring-operator/charts/promxy/templates/secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/promxy/templates/secret.yaml
@@ -4,12 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ .Values.name }}-config
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}-config
-    app.kubernetes.io/instance: {{ cat .Values.name "-config-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promxy
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promxy.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (printf "%s-config" .Values.name) "component" "promxy") | nindent 4 }}
 type: Opaque
 stringData:
   config.yaml: |

--- a/charts/qubership-monitoring-operator/charts/promxy/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/promxy/templates/service.yaml
@@ -4,12 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: promxy
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "promxy.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "promxy") | nindent 4 }}
 spec:
   ports:
     - name: web

--- a/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/deployment.yaml
@@ -4,12 +4,11 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: stackdriver-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "stackdriver-exporter") | nindent 4 }}
     {{- $image := include "stackdriver-exporter.image" . }}
+    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
     app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
       {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -26,12 +25,10 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "stackdriver-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: stackdriver-exporter
-        app.kubernetes.io/part-of: monitoring
         app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
           {{- toYaml .Values.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/secret.yaml
@@ -4,12 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: stackdriver-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "stackdriver-exporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "stackdriver-exporter") | nindent 4 }}
 type: Opaque
 data:
   credentials.json: {{ .Values.stackdriver.serviceAccountKey | b64enc | quote }}

--- a/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/service.yaml
@@ -4,12 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: stackdriver-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "stackdriver-exporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "stackdriver-exporter") | nindent 4 }}
     {{- if .Values.labels }}
       {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/serviceaccount.yaml
@@ -4,12 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
-    app.kubernetes.io/instance: {{ cat .Values.serviceAccount.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: stackdriver-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "stackdriver-exporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.serviceAccount.name "component" "stackdriver-exporter") | nindent 4 }}
   {{- if .Values.labels }}
     {{- toYaml .Values.labels | nindent 4 }}
   {{- end }}

--- a/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/stackdriver-exporter/templates/servicemonitor.yaml
@@ -4,11 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Release.Namespace "-" .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "stackdriver-exporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "stackdriver-exporter" "processedByOperator" "prometheus-operator") | nindent 4 }}
     {{- if .Values.serviceMonitor.labels }}
       {{ toYaml .Values.serviceMonitor.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/clusterrole.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/clusterrole.yaml
@@ -4,11 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "version-exporter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "version-exporter.rbac.fullname" . }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "version-exporter.rbac.fullname" .) "component" "version-exporter") | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/clusterrolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/clusterrolebinding.yaml
@@ -4,12 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "version-exporter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "version-exporter.rbac.fullname" . }}
-    app.kubernetes.io/instance: {{ cat .Release.Namespace "-" .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "version-exporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "version-exporter.rbac.fullname" .) "component" "version-exporter") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/configmap.yaml
@@ -4,11 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "version-exporter") | nindent 4 }}
 data:
   {{- if .Values.exporterConfig }}
   exporterConfig.yaml: |-

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/dashboard.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/dashboard.yaml
@@ -4,11 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "grafana-operator") | nindent 4 }}
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/deployment.yaml
@@ -4,13 +4,12 @@ kind: Deployment
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "version-exporter") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
     app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    app.kubernetes.io/technology: go
     {{- if .Values.labels }}
-      {{ toYaml .Values.labels | nindent 4 }}
+    {{ toYaml .Values.labels | nindent 4 }}
     {{- end }}
   {{- if .Values.annotations }}
   annotations:
@@ -25,14 +24,12 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
-        app.kubernetes.io/component: version-exporter
-        app.kubernetes.io/part-of: monitoring
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "version-exporter") | nindent 8 }}
         app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
         app.kubernetes.io/version: {{ template "version-exporter.version" . }}
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/technology: go
         {{- if .Values.labels }}
-          {{ toYaml .Values.labels | nindent 8 }}
+        {{ toYaml .Values.labels | nindent 8 }}
         {{- end }}
       {{- if .Values.annotations }}
       annotations:

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/role.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/role.yaml
@@ -4,11 +4,7 @@ kind: Role
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "version-exporter") | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/rolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/rolebinding.yaml
@@ -4,11 +4,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "version-exporter") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccount.name }}

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/secret.yaml
@@ -4,11 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Values.secretName }}
   labels:
-    app.kubernetes.io/name: {{ .Values.secretName }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.secretName "component" "version-exporter") | nindent 4 }}
 type: Opaque
 stringData:
   {{- range $key, $val := .Values.extraVarsSecret }}

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/service.yaml
@@ -4,11 +4,7 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "version-exporter") | nindent 4 }}
     {{- if .Values.service.labels }}
       {{ toYaml .Values.service.labels | indent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/serviceaccount.yaml
@@ -4,11 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
-    app.kubernetes.io/component: version-exporter
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.serviceAccount.name "component" "version-exporter") | nindent 4 }}
     {{- if .Values.service.labels }}
       {{ toYaml .Values.service.labels | indent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/version-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/version-exporter/templates/servicemonitor.yaml
@@ -4,11 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "version-exporter.instance" . }}
-    app.kubernetes.io/version: {{ template "version-exporter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.name "component" "monitoring" "processedByOperator" "prometheus-operator") | nindent 4 }}
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval | default "5m" }}

--- a/charts/qubership-monitoring-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/templates/_helpers.tpl
@@ -1,6 +1,27 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Resource labels: name, app.kubernetes.io/name, component, part-of, managed-by.
+Optional: processedByOperator (for CRs only).
+Usage: {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $name "component" $component) | nindent 4 }}
+       For CRs: add "processedByOperator" "prometheus-adapter-operator"
+       For workloads (Deployment, StatefulSet, DaemonSet), add instance, version, technology inline.
+*/}}
+{{- define "monitoring.resourceLabels" -}}
+{{- $ctx := .ctx -}}
+{{- $name := .name -}}
+{{- $component := .component -}}
+name: {{ $name }}
+app.kubernetes.io/name: {{ $name }}
+app.kubernetes.io/component: {{ $component }}
+app.kubernetes.io/part-of: {{ (index $ctx.Values "global" | default dict).partOf | default "monitoring" }}
+app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
+{{- if .processedByOperator }}
+app.kubernetes.io/processed-by-operator: {{ .processedByOperator }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Expand the name of the chart. This is suffixed with -alertmanager, which means subtract 13 from longest 63 available
 */}}
 {{- define "monitoring.name" -}}

--- a/charts/qubership-monitoring-operator/values.yaml
+++ b/charts/qubership-monitoring-operator/values.yaml
@@ -9,6 +9,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 global:
+  # Common labels for subcharts (app.kubernetes.io/part-of)
+  partOf: monitoring
+
   # Indicates if monitoring-operator has permissions to deploy ClusterRole and
   # ClusterRoleBinding resources.
   # If set to `true` deploy all resources. Otherwise, deploy only Role and RoleBinding


### PR DESCRIPTION
    - Apply monitoring.resourceLabels (from root chart) to all exporter subcharts
    - blackbox-exporter, cert-exporter, cloud-events-exporter, cloudwatch-exporter
    - goldpinger-exporter, graphite-remote-adapter, json-exporter, network-latency-exporter
    - promitor-agent-resource-discovery, promitor-agent-scraper, promxy
    - stackdriver-exporter, version-exporter, common-dashboards
    - Remove common-labels subchart dependency from exporter Chart.yaml files