### PR TITLE
fix: add app.kubernetes.io labels to operator subcharts

### DIFF
--- a/charts/qubership-monitoring-operator/charts/grafana-operator/templates/configmap-extra-vars.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana-operator/templates/configmap-extra-vars.yaml
@@ -3,11 +3,7 @@ kind: ConfigMap
 metadata:
   name: grafana-extra-vars
   labels:
-    app.kubernetes.io/name: grafana-extra-vars
-    app.kubernetes.io/instance: {{ cat "grafana-extra-vars-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: grafana
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "grafana-extra-vars" "component" "grafana") | nindent 4 }}
 {{- if .Values.extraVars }}
 data:
   {{- range $key, $val := .Values.extraVars }}

--- a/charts/qubership-monitoring-operator/charts/grafana-operator/templates/dashboard-home.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana-operator/templates/dashboard-home.yaml
@@ -4,11 +4,7 @@ kind: ConfigMap
 metadata:
   name: grafana-home-dashboard
   labels:
-    app.kubernetes.io/name: grafana-home-dashboard
-    app.kubernetes.io/instance: {{ cat "grafana-home-dashboard-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "grafana-home-dashboard" "component" "monitoring") | nindent 4 }}
 data:
   grafana-home-dashboard.json: |-
     {

--- a/charts/qubership-monitoring-operator/charts/grafana-operator/templates/image-renderer/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana-operator/templates/image-renderer/deployment.yaml
@@ -1,16 +1,17 @@
 {{- if .Values.imageRenderer.install }}
 {{- $image := include "grafana.imageRenderer.image" . }}
+{{- $name := .Values.imageRenderer.name }}
+{{- $instance := printf "%s-%s" $name .Release.Namespace | trunc 63 | trimSuffix "-" }}
+{{- $version := splitList ":" $image | last }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: {{ .Values.imageRenderer.name }}
+  name: {{ $name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.imageRenderer.name }}
-    app.kubernetes.io/instance: {{ cat .Values.imageRenderer.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: grafana
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
-    app: {{ .Values.imageRenderer.name }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $name "component" "grafana") | nindent 4 }}
+    app.kubernetes.io/instance: {{ $instance }}
+    app.kubernetes.io/version: {{ $version | quote }}
+    app.kubernetes.io/technology: node-js
     {{- if .Values.imageRenderer.labels }}
       {{- toYaml .Values.imageRenderer.labels | nindent 4 }}
     {{- end }}
@@ -22,17 +23,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Values.imageRenderer.name }}
+      app.kubernetes.io/name: {{ $name }}
   template:
     metadata:
       labels:
-        app: {{ .Values.imageRenderer.name }}
-        app.kubernetes.io/name: {{ .Values.imageRenderer.name }}
-        app.kubernetes.io/instance: {{ cat .Values.imageRenderer.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: grafana
-        app.kubernetes.io/part-of: monitoring
-        app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $name "component" "grafana") | nindent 8 }}
+        app.kubernetes.io/instance: {{ $instance }}
+        app.kubernetes.io/version: {{ $version | quote }}
+        app.kubernetes.io/technology: node-js
         {{- if .Values.imageRenderer.labels }}
           {{- toYaml .Values.imageRenderer.labels | nindent 8 }}
         {{- end }}

--- a/charts/qubership-monitoring-operator/charts/grafana-operator/templates/image-renderer/secret-admin-credentials-temp.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana-operator/templates/image-renderer/secret-admin-credentials-temp.yaml
@@ -4,11 +4,7 @@ kind: Secret
 metadata:
   name: grafana-admin-credentials-temp
   labels:
-    app.kubernetes.io/name: grafana-admin-credentials-temp
-    app.kubernetes.io/instance: {{ cat "grafana-admin-credentials-temp-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: grafana
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "grafana-admin-credentials-temp" "component" "grafana" "managedByOperator" "monitoring-operator") | nindent 4 }}
 type: Opaque
 stringData:
   GF_SECURITY_ADMIN_USER: {{ .Values.security.admin_user }}

--- a/charts/qubership-monitoring-operator/charts/grafana-operator/templates/image-renderer/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana-operator/templates/image-renderer/service.yaml
@@ -1,15 +1,11 @@
 {{- if .Values.imageRenderer.install }}
-{{- $image := include "grafana.imageRenderer.image" . }}
+{{- $name := .Values.imageRenderer.name }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.imageRenderer.name }}
+  name: {{ $name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.imageRenderer.name }}
-    app.kubernetes.io/instance: {{ cat .Values.imageRenderer.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: grafana
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $name "component" "grafana") | nindent 4 }}
     {{- if .Values.imageRenderer.labels }}
       {{- toYaml .Values.imageRenderer.labels | nindent 4 }}
     {{- end }}

--- a/charts/qubership-monitoring-operator/charts/grafana-operator/templates/secret-ldap-config.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana-operator/templates/secret-ldap-config.yaml
@@ -3,11 +3,7 @@ kind: Secret
 metadata:
   name: grafana-ldap-config
   labels:
-    app.kubernetes.io/name: grafana-ldap-config
-    app.kubernetes.io/instance: {{ cat "grafana-ldap-config-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: grafana
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "grafana-ldap-config" "component" "grafana" "managedByOperator" "monitoring-operator") | nindent 4 }}
 type: Opaque
 stringData:
 {{- if .Values.ldapConfig }}

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/_helpers.tpl
@@ -29,16 +29,6 @@ Image can be found from:
 {{- end -}}
 
 {{/*
-Create common labels for each resource which is creating by this chart.
-*/}}
-{{- define "prometheusAdapter.commonLabels" -}}
-app.kubernetes.io/component: prometheus-adapter
-app.kubernetes.io/part-of: monitoring
-{{- $image := include "prometheusAdapter.operator.image" . }}
-app.kubernetes.io/version: {{ splitList ":" $image | last }}
-{{- end }}
-
-{{/*
 Generate prometheusUrl for prometheus-adapter if it not defined
 */}}
 {{- define "prometheusAdapter.prometheusUrl" -}}

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/apiservice-custom-metrics.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/apiservice-custom-metrics.yaml
@@ -4,9 +4,7 @@ kind: APIService
 metadata:
   name: v1beta1.custom.metrics.k8s.io
   labels:
-    app.kubernetes.io/name: v1beta1.custom.metrics.k8s.io
-    app.kubernetes.io/instance: v1beta1.custom.metrics.k8s.io
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "v1beta1.custom.metrics.k8s.io" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "5"

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/apiservice-resource-metrics.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/apiservice-resource-metrics.yaml
@@ -4,9 +4,7 @@ kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io
   labels:
-    app.kubernetes.io/name: v1beta1.metrics.k8s.io
-    app.kubernetes.io/instance: v1beta1.metrics.k8s.io
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "v1beta1.metrics.k8s.io" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
   annotations:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "5"

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/clusterrole.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/clusterrole.yaml
@@ -4,9 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ template "prometheusAdapter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "prometheusAdapter.rbac.fullname" . }}
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "prometheusAdapter.rbac.fullname" .) "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 rules:
   # Need to discover CRs in all namespaces
   - apiGroups:

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/clusterrolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/clusterrolebinding.yaml
@@ -4,9 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "prometheusAdapter.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ template "prometheusAdapter.rbac.fullname" . }}
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "prometheusAdapter.rbac.fullname" .) "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: prometheus-adapter-operator

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/configmap.yaml
@@ -3,9 +3,7 @@ kind: ConfigMap
 metadata:
   name: prometheus-adapter-resource-rules
   labels:
-    app.kubernetes.io/name: prometheus-adapter-resource-rules
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-adapter-resource-rules" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 data:
   config.yaml: |
   {{- if .Values.configResourceMetrics }}

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/customscalemetricrule-kubelet-metrics.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/customscalemetricrule-kubelet-metrics.yaml
@@ -4,11 +4,7 @@ kind: CustomScaleMetricRule
 metadata:
   name: kubelet-custom-metric-rule
   labels:
-    app.kubernetes.io/name: kubelet-custom-metric-rule
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    app.kubernetes.io/version: {{ template "prometheusAdapter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "kubelet-custom-metric-rule" "component" "monitoring" "managedByOperator" "prometheus-adapter-operator" "processedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 spec:
   rules:
     # Container/Pod CPU usage metrics

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/deployment.yaml
@@ -4,9 +4,10 @@ kind: Deployment
 metadata:
   name: prometheus-adapter-operator
   labels:
-    app.kubernetes.io/name: prometheus-adapter-operator
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-adapter-operator" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
     app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/version: {{ include "prometheusAdapter.operator.image" . | splitList ":" | last | quote }}
+    app.kubernetes.io/technology: go
     {{- if .Values.operator.labels }}
       {{- toYaml .Values.operator.labels | nindent 4 }}
     {{- end }}
@@ -22,10 +23,10 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: prometheus-adapter-operator
-        app.kubernetes.io/instance: {{ cat "prometheus-adapter-operator-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        {{- include "prometheusAdapter.commonLabels" . | nindent 8 }}
-        app.kubernetes.io/managed-by: Helm
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-adapter-operator" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 8 }}
+        app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
+        app.kubernetes.io/version: {{ include "prometheusAdapter.operator.image" . | splitList ":" | last | quote }}
+        app.kubernetes.io/technology: go
       {{- if .Values.operator.labels }}
         {{- toYaml .Values.operator.labels | nindent 8 }}
       {{- end }}

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/prometheusadapter.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/prometheusadapter.yaml
@@ -4,11 +4,7 @@ kind: PrometheusAdapter
 metadata:
   name: prometheus-adapter
   labels:
-    app.kubernetes.io/name: prometheus-adapter
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    app.kubernetes.io/version: {{ template "prometheusAdapter.version" . }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-adapter" "component" "monitoring" "managedByOperator" "prometheus-adapter-operator" "processedByOperator" "prometheus-adapter-operator") | nindent 4 }}
     {{- if .Values.labels }}
       {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
@@ -63,7 +59,7 @@ spec:
   {{- else }}
   {{-  if .Values.operator.tlsConfig.existingSecret }}
   tlsConfig:
-    caSecret: 
+    caSecret:
       key: "ca.crt"
       name: {{ .Values.operator.tlsConfig.existingSecret }}
     certSecret:
@@ -75,7 +71,7 @@ spec:
   {{- else }}
   {{- if and .Values.operator.tlsConfig.generateCerts .Values.operator.tlsConfig.generateCerts.enabled }}
   tlsConfig:
-    caSecret: 
+    caSecret:
       key: "ca.crt"
       name: {{ default "prometheus-adapter-client-tls-secret" .Values.operator.tlsConfig.generateCerts.secretName }}
     certSecret:
@@ -86,7 +82,7 @@ spec:
       name: {{ default "prometheus-adapter-client-tls-secret" .Values.operator.tlsConfig.generateCerts.secretName }}
   {{- else }}
   tlsConfig:
-    caSecret: 
+    caSecret:
       key: "ca.crt"
       name: {{ default "prometheus-adapter-client-tls-secret" .Values.operator.tlsConfig.createSecret.secretName }}
     certSecret:

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/role.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/role.yaml
@@ -4,9 +4,7 @@ kind: Role
 metadata:
   name: prometheus-adapter-operator
   labels:
-    app.kubernetes.io/name: prometheus-adapter-operator
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-adapter-operator" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 rules:
   # Permissions for leader election
   - apiGroups:

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/rolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/rolebinding.yaml
@@ -4,9 +4,7 @@ kind: RoleBinding
 metadata:
   name: prometheus-adapter-operator
   labels:
-    app.kubernetes.io/name: prometheus-adapter-operator
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-adapter-operator" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: prometheus-adapter-operator

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/secret-basic-auth.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/secret-basic-auth.yaml
@@ -5,9 +5,7 @@ kind: Secret
 metadata:
   name: prometheus-adapter-client-basic-auth
   labels:
-    app.kubernetes.io/name: prometheus-adapter-client-basic-auth
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-adapter-client-basic-auth" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 type: kubernetes.io/basic-auth
 stringData:
   username: {{ .Values.auth.basicAuth.createSecret.username }}

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/secret-tls-assets.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/secret-tls-assets.yaml
@@ -6,9 +6,7 @@ kind: Secret
 metadata:
   name: {{ default "prometheus-adapter-client-tls-secret" .Values.operator.tlsConfig.createSecret.secretName }}
   labels:
-    app.kubernetes.io/name: {{ default "prometheus-adapter-client-tls-secret" .Values.operator.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "prometheus-adapter-client-tls-secret" .Values.operator.tlsConfig.createSecret.secretName) "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.operator.tlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-adapter-operator/templates/serviceaccount.yaml
@@ -4,7 +4,5 @@ kind: ServiceAccount
 metadata:
   name: prometheus-adapter-operator
   labels:
-    app.kubernetes.io/name: prometheus-adapter-operator
-    app.kubernetes.io/instance: {{ template "prometheusAdapter.instance" . }}
-    {{- include "prometheusAdapter.commonLabels" . | nindent 4 }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-adapter-operator" "component" "prometheus-adapter" "managedByOperator" "prometheus-adapter-operator") | nindent 4 }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/certificate.yaml
@@ -6,11 +6,7 @@ kind: Certificate
 metadata:
   name: prometheus-tls-certificate
   labels:
-    app.kubernetes.io/name: prometheus-tls-certificate
-    app.kubernetes.io/instance: {{ cat "prometheus-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-tls-certificate" "component" "prometheus") | nindent 4 }}
 spec:
   secretName: {{ default "prometheus-cert-manager-tls" .Values.tlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.tlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/issuer.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/issuer.yaml
@@ -6,11 +6,7 @@ kind: Issuer
 metadata:
   name: prometheus-tls-issuer
   labels:
-    app.kubernetes.io/name: prometheus-tls-issuer
-    app.kubernetes.io/instance: {{ cat "prometheus-tls-issuer-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "prometheus-tls-issuer" "component" "prometheus") | nindent 4 }}
 spec:
   selfSigned: {}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-additional-alertmanager-configs.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-additional-alertmanager-configs.yaml
@@ -3,11 +3,7 @@ kind: Secret
 metadata:
   name: additional-alertmanager-configs
   labels:
-    app.kubernetes.io/name: additional-alertmanager-configs
-    app.kubernetes.io/instance: {{ cat "additional-alertmanager-configs-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "additional-alertmanager-configs" "component" "prometheus") | nindent 4 }}
 type: Opaque
 {{- if .Values.additionalAlertManager }}
 stringData:

--- a/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-additional-alertrelabel-configs.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-additional-alertrelabel-configs.yaml
@@ -3,11 +3,7 @@ kind: Secret
 metadata:
   name: additional-alertrelabel-configs
   labels:
-    app.kubernetes.io/name: additional-alertrelabel-configs
-    app.kubernetes.io/instance: {{ cat "additional-alertrelabel-configs-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "additional-alertrelabel-configs" "component" "prometheus") | nindent 4 }}
 type: Opaque
 {{- if .Values.additionalAlertRelabel }}
 stringData:

--- a/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-additional-scrape-configs.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-additional-scrape-configs.yaml
@@ -3,11 +3,7 @@ kind: Secret
 metadata:
   name: additional-scrape-configs
   labels:
-    app.kubernetes.io/name: additional-scrape-configs
-    app.kubernetes.io/instance: {{ cat "additional-scrape-configs-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "additional-scrape-configs" "component" "prometheus") | nindent 4 }}
 type: Opaque
 {{- if .Values.additionalScrape }}
 stringData:

--- a/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-remote-write-creds.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-remote-write-creds.yaml
@@ -8,11 +8,7 @@ kind: Secret
 metadata:
   name: {{ .basicAuth.createSecret.secretName }}
   labels:
-    app.kubernetes.io/name: {{ .basicAuth.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat .basicAuth.createSecret.secretName "-" $.Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" .basicAuth.createSecret.secretName "component" "prometheus") | nindent 4 }}
 stringData:
   username: {{ .basicAuth.createSecret.username }}
   password: {{ .basicAuth.createSecret.password }}

--- a/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-tls-assets.yaml
+++ b/charts/qubership-monitoring-operator/charts/prometheus-operator/templates/secret-tls-assets.yaml
@@ -5,11 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "prometheus-tls" .Values.tlsConfig.createSecret.name }}
   labels:
-    app.kubernetes.io/name: {{ default "prometheus-tls" .Values.tlsConfig.createSecret.name }}
-    app.kubernetes.io/instance: {{ cat (default "prometheus-tls" .Values.tlsConfig.createSecret.name) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: prometheus
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "prometheus-tls" .Values.tlsConfig.createSecret.name) "component" "prometheus") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.tlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/pre-delete/job.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/pre-delete/job.yaml
@@ -4,11 +4,7 @@ kind: Job
 metadata:
   name: {{ include "vm.cleanup.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "vm.cleanup.rbac.fullname" . }}
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ include "vm.cleanup.rbac.fullname" . }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "vm.cleanup.rbac.fullname" .) "component" "victoriametrics") | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
@@ -18,11 +14,7 @@ spec:
     metadata:
       name: {{ include "vm.cleanup.rbac.fullname" . }}
       labels:
-        app.kubernetes.io/name: {{ include "vm.cleanup.rbac.fullname" . }}
-        app.kubernetes.io/component: victoriametrics
-        app.kubernetes.io/part-of: monitoring
-        app.kubernetes.io/instance: {{ include "vm.cleanup.rbac.fullname" . }}
-        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+        {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "vm.cleanup.rbac.fullname" .) "component" "victoriametrics") | nindent 8 }}
     spec:
       serviceAccountName: {{ include "vm.cleanup.rbac.fullname" . }}
       restartPolicy: OnFailure

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/pre-delete/role.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/pre-delete/role.yaml
@@ -4,11 +4,7 @@ kind: Role
 metadata:
   name: {{ include "vm.cleanup.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "vm.cleanup.rbac.fullname" . }}
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ include "vm.cleanup.rbac.fullname" . }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "vm.cleanup.rbac.fullname" .) "component" "victoriametrics") | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/pre-delete/rolebinding.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/pre-delete/rolebinding.yaml
@@ -4,11 +4,7 @@ kind: RoleBinding
 metadata:
   name: {{ include "vm.cleanup.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "vm.cleanup.rbac.fullname" . }}
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ include "vm.cleanup.rbac.fullname" . }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "vm.cleanup.rbac.fullname" .) "component" "victoriametrics") | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/pre-delete/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/pre-delete/serviceaccount.yaml
@@ -4,11 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "vm.cleanup.rbac.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "vm.cleanup.rbac.fullname" . }}
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ include "vm.cleanup.rbac.fullname" . }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (include "vm.cleanup.rbac.fullname" .) "component" "victoriametrics") | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/secret-additional-scrape-configs.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/secret-additional-scrape-configs.yaml
@@ -3,11 +3,7 @@ kind: Secret
 metadata:
   name: vm-additional-scrape-configs
   labels:
-    app.kubernetes.io/name: vm-additional-scrape-configs
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ cat "vm-additional-scrape-configs-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vm-additional-scrape-configs" "component" "victoriametrics") | nindent 4 }}
 type: Opaque
 {{- if .Values.vmAgent.additionalScrape }}
 stringData:

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/secret-remote-write-creds.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/secret-remote-write-creds.yaml
@@ -9,11 +9,7 @@ kind: Secret
 metadata:
   name: {{ .basicAuth.createSecret.secretName }}
   labels:
-    app.kubernetes.io/name: {{ .basicAuth.createSecret.secretName }}
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ cat .basicAuth.createSecret.secretName "-" $.Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" $ "name" .basicAuth.createSecret.secretName "component" "victoriametrics") | nindent 4 }}
 stringData:
   username: {{ .basicAuth.createSecret.username }}
   password: {{ .basicAuth.createSecret.password }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/secret-vmagent-extra-vars.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/secret-vmagent-extra-vars.yaml
@@ -4,11 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Values.vmAgent.secretName }}
   labels:
-    app.kubernetes.io/name: {{ .Values.vmAgent.secretName }}
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ cat .Values.vmAgent.secretName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.vmAgent.secretName "component" "victoriametrics") | nindent 4 }}
 type: Opaque
 stringData:
   {{- range $key, $val := .Values.vmAgent.extraVarsSecret }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/secret-vmauth-extra-vars.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/secret-vmauth-extra-vars.yaml
@@ -4,11 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Values.vmAuth.secretName }}
   labels:
-    app.kubernetes.io/name: {{ .Values.vmAuth.secretName }}
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ cat .Values.vmAuth.secretName "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" .Values.vmAuth.secretName "component" "victoriametrics") | nindent 4 }}
 type: Opaque
 stringData:
   {{- range $key, $val := .Values.vmAuth.extraVarsSecret }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmagent-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmagent-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vmagent-tls-certificate
   labels:
-    app.kubernetes.io/name: vmagent-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vmagent-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmAgent
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmagent-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vmagent-tls-secret" .Values.vmAgent.tlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmAgent.tlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmagent-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmagent-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vmagent-tls-secret" .Values.vmAgent.tlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vmagent-tls-secret" .Values.vmAgent.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vmagent-tls-secret" .Values.vmAgent.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vmagent-tls-secret" .Values.vmAgent.tlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmagent
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vmagent-tls-secret" .Values.vmAgent.tlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmAgent.tlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmalert-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmalert-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vmalert-tls-certificate
   labels:
-    app.kubernetes.io/name: vmalert-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vmalert-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmAlert
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmalert-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vmalert-tls-secret" .Values.vmAlert.tlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmAlert.tlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmalert-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmalert-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vmalert-tls-secret" .Values.vmAlert.tlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vmalert-tls-secret" .Values.vmAlert.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vmalert-tls-secret" .Values.vmAlert.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vmalert-tls-secret" .Values.vmAlert.tlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmalert
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vmalert-tls-secret" .Values.vmAlert.tlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmAlert.tlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmalertmanager-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmalertmanager-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vmalertmanager-tls-certificate
   labels:
-    app.kubernetes.io/name: vmalertmanager-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vmalertmanager-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmAlertManager
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmalertmanager-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vmalertmanager-tls-secret" .Values.vmAlertManager.tlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmAlertManager.tlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmalertmanager-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmalertmanager-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vmalertmanager-tls-secret" .Values.vmAlertManager.tlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vmalertmanager-tls-secret" .Values.vmAlertManager.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vmalertmanager-tls-secret" .Values.vmAlertManager.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vmalertmanager-tls-secret" .Values.vmAlertManager.tlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmalertmanager
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vmalertmanager-tls-secret" .Values.vmAlertManager.tlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmAlertManager.tlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmauth-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmauth-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vmauth-tls-certificate
   labels:
-    app.kubernetes.io/name: vmauth-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vmauth-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmAuth
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmauth-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vmauth-tls-secret" .Values.vmAuth.tlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmAuth.tlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmauth-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmauth-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vmauth-tls-secret" .Values.vmAuth.tlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vmauth-tls-secret" .Values.vmAuth.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vmauth-tls-secret" .Values.vmAuth.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vmauth-tls-secret" .Values.vmAuth.tlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmauth
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vmauth-tls-secret" .Values.vmAuth.tlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmAuth.tlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vminsert-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vminsert-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vminsert-tls-certificate
   labels:
-    app.kubernetes.io/name: vminsert-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vminsert-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmInsert
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vminsert-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vminsert-tls-secret" .Values.vmCluster.vmInsertTlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmCluster.vmInsertTlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vminsert-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vminsert-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vminsert-tls-secret" .Values.vmCluster.vmInsertTlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vminsert-tls-secret" .Values.vmCluster.vmInsertTlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vminsert-tls-secret" .Values.vmCluster.vmInsertTlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vminsert-tls-secret" .Values.vmCluster.vmInsertTlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: victoriametrics-operator
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vminsert-tls-secret" .Values.vmCluster.vmInsertTlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmCluster.vmInsertTlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmoperator-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmoperator-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vmoperator-tls-certificate
   labels:
-    app.kubernetes.io/name: vmoperator-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vmoperator-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmOperator
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmoperator-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vmoperator-tls-secret" .Values.vmOperator.tlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmOperator.tlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmoperator-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmoperator-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vmoperator-tls-secret" .Values.vmOperator.tlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vmoperator-tls-secret" .Values.vmOperator.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vmoperator-tls-secret" .Values.vmOperator.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vmoperator-tls-secret" .Values.vmOperator.tlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: victoriametrics-operator
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vmoperator-tls-secret" .Values.vmOperator.tlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmOperator.tlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmselect-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmselect-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vmselect-tls-certificate
   labels:
-    app.kubernetes.io/name: vmselect-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vmselect-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmSelect
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmselect-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vmselect-tls-secret" .Values.vmCluster.vmSelectTlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmCluster.vmSelectTlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmselect-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmselect-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vmselect-tls-secret" .Values.vmCluster.vmSelectTlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vmselect-tls-secret" .Values.vmCluster.vmSelectTlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vmselect-tls-secret" .Values.vmCluster.vmSelectTlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vmselect-tls-secret" .Values.vmCluster.vmSelectTlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: victoriametrics-operator
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vmselect-tls-secret" .Values.vmCluster.vmSelectTlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmCluster.vmSelectTlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmsingle-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmsingle-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vmsingle-tls-certificate
   labels:
-    app.kubernetes.io/name: vmsingle-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vmsingle-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmSingle
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmsingle-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vmsingle-tls-secret" .Values.vmSingle.tlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmSingle.tlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmsingle-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmsingle-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vmsingle-tls-secret" .Values.vmSingle.tlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vmsingle-tls-secret" .Values.vmSingle.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vmsingle-tls-secret" .Values.vmSingle.tlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vmsingle-tls-secret" .Values.vmSingle.tlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmsingle
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vmsingle-tls-secret" .Values.vmSingle.tlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmSingle.tlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmstorage-certificate.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmstorage-certificate.yaml
@@ -5,11 +5,7 @@ kind: Certificate
 metadata:
   name: vmstorage-tls-certificate
   labels:
-    app.kubernetes.io/name: vmstorage-tls-certificate
-    app.kubernetes.io/instance: {{ cat "vmstorage-tls-certificate-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: vmStorage
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmstorage-tls-certificate" "component" "victoriametrics") | nindent 4 }}
 spec:
   secretName: {{ default "vmstorage-tls-secret" .Values.vmCluster.vmStorageTlsConfig.generateCerts.secretName }}
   duration: {{ default 365 .Values.vmCluster.vmStorageTlsConfig.generateCerts.duration | mul 24 }}h

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmstorage-tls-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmstorage-tls-secret.yaml
@@ -5,10 +5,7 @@ apiVersion: v1
 metadata:
   name: {{ default "vmstorage-tls-secret" .Values.vmCluster.vmStorageTlsConfig.createSecret.secretName }}
   labels:
-    name: {{ default "vmstorage-tls-secret" .Values.vmCluster.vmStorageTlsConfig.createSecret.secretName }}
-    app.kubernetes.io/name: {{ default "vmstorage-tls-secret" .Values.vmCluster.vmStorageTlsConfig.createSecret.secretName }}
-    app.kubernetes.io/instance: {{ cat (default "vmstorage-tls-secret" .Values.vmCluster.vmStorageTlsConfig.createSecret.secretName) "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: victoriametrics-operator
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" (default "vmstorage-tls-secret" .Values.vmCluster.vmStorageTlsConfig.createSecret.secretName) "component" "victoriametrics") | nindent 4 }}
 data: {}
 stringData:
   {{- if .Values.vmCluster.vmStorageTlsConfig.createSecret.ca }}

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmuser-secret.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/templates/vmuser-secret.yaml
@@ -3,11 +3,7 @@ kind: Secret
 metadata:
   name: vmuser-secret
   labels:
-    app.kubernetes.io/name: vmuser-secret
-    app.kubernetes.io/component: victoriametrics
-    app.kubernetes.io/part-of: monitoring
-    app.kubernetes.io/instance: {{ cat "vmuser-secret-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "monitoring.resourceLabels" (dict "ctx" . "name" "vmuser-secret" "component" "victoriametrics") | nindent 4 }}
 type: Opaque
 stringData:
   password: {{ .Values.vmUser.password }}

--- a/charts/qubership-monitoring-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/templates/_helpers.tpl
@@ -1,6 +1,27 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Resource labels: name, app.kubernetes.io/name, component, part-of, managed-by.
+Optional: processedByOperator (for CRs only).
+Usage: {{- include "monitoring.resourceLabels" (dict "ctx" . "name" $name "component" $component) | nindent 4 }}
+       For CRs: add "processedByOperator" "prometheus-adapter-operator"
+       For workloads (Deployment, StatefulSet, DaemonSet), add instance, version, technology inline.
+*/}}
+{{- define "monitoring.resourceLabels" -}}
+{{- $ctx := .ctx -}}
+{{- $name := .name -}}
+{{- $component := .component -}}
+name: {{ $name }}
+app.kubernetes.io/name: {{ $name }}
+app.kubernetes.io/component: {{ $component }}
+app.kubernetes.io/part-of: {{ (index $ctx.Values "global" | default dict).partOf | default "monitoring" }}
+app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
+{{- if .processedByOperator }}
+app.kubernetes.io/processed-by-operator: {{ .processedByOperator }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Expand the name of the chart. This is suffixed with -alertmanager, which means subtract 13 from longest 63 available
 */}}
 {{- define "monitoring.name" -}}

--- a/charts/qubership-monitoring-operator/values.yaml
+++ b/charts/qubership-monitoring-operator/values.yaml
@@ -9,6 +9,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 global:
+  # Common labels for subcharts (app.kubernetes.io/part-of)
+  partOf: monitoring
+
   # Indicates if monitoring-operator has permissions to deploy ClusterRole and
   # ClusterRoleBinding resources.
   # If set to `true` deploy all resources. Otherwise, deploy only Role and RoleBinding


### PR DESCRIPTION
    - Apply monitoring.resourceLabels to grafana-operator, prometheus-operator,
      prometheus-adapter-operator, victoriametrics-operator