### PR TITLE
feat: labels setup for blackbox-exporter subchart

### DIFF
--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/_helpers.tpl
@@ -27,3 +27,5 @@ Return securityContext for blackboxExporter.
         {}
     {{- end -}}
 {{- end -}}
+
+{{/* no chart-specific label helpers; use root monitoring.* helpers + inline workload labels in templates */}}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/_helpers.tpl
@@ -27,5 +27,3 @@ Return securityContext for blackboxExporter.
         {}
     {{- end -}}
 {{- end -}}
-
-{{/* no chart-specific label helpers; use root monitoring.* helpers + inline workload labels in templates */}}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/configmap.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/configmap.yaml
@@ -4,12 +4,7 @@ kind: {{ if .Values.secretConfig -}} Secret {{- else -}} ConfigMap {{- end }}
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.labels" . | nindent 4 }}
 {{ if .Values.secretConfig -}}
 stringData: {{- else -}} data: {{- end }}
   blackbox.yaml: |

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/daemonset.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/daemonset.yaml
@@ -1,18 +1,15 @@
 {{- if and .Values.install .Values.asDaemonSet }}
+{{- $name := .Values.name -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ .Values.name }}
+  name: {{ $name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
-    {{- if .Values.labels }}
-    {{- toYaml .Values.labels | nindent 4 }}
-    {{- end }}
+    {{- include "monitoring.labels" . | nindent 4 }}
+    app.kubernetes.io/instance: {{ cat $name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/version: {{ splitList ":" (include "blackboxExporter.image" .) | last }}
+    app.kubernetes.io/technology: go
+    {{- include "monitoring.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
@@ -20,26 +17,22 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.name }}
+      app: {{ $name }}
   template:
     metadata:
       labels:
-        app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
-        app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: blackbox-exporter
-        app.kubernetes.io/part-of: monitoring
-        app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
-        {{- if .Values.labels }}
-        {{- toYaml .Values.labels | nindent 8 }}
-        {{- end }}
+        app: {{ $name }}
+        {{- include "monitoring.labels" . | nindent 8 }}
+        app.kubernetes.io/instance: {{ cat $name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+        app.kubernetes.io/version: {{ splitList ":" (include "blackboxExporter.image" .) | last }}
+        app.kubernetes.io/technology: go
+        {{- include "monitoring.extraLabels" . | nindent 8 }}
       {{- if .Values.annotations }}
       annotations:
         {{- toYaml .Values.annotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ .Values.name }}
+      serviceAccountName: {{ $name }}
       securityContext:
         {{ include "blackboxExporter.securityContext" . }}
       tolerations:
@@ -89,12 +82,12 @@ spec:
       - name: config
         {{- if .Values.secretConfig }}
         secret:
-          secretName: {{ .Values.name }}
+          secretName: {{ $name }}
         {{- else if .Values.configExistingSecretName }}
         secret:
           secretName: {{ .Values.configExistingSecretName }}
         {{- else }}
         configMap:
-          name: {{ .Values.name }}
+          name: {{ $name }}
         {{- end }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/dashboard.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/dashboard.yaml
@@ -4,7 +4,7 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}
   labels:
-    {{- include "monitoring.labels" (dict "ctx" .) | nindent 4 }}
+    {{- include "monitoring.labels" . | nindent 4 }}
     app.kubernetes.io/processed-by-operator: grafana-operator
 spec:
   json: >

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/dashboard.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/dashboard.yaml
@@ -4,12 +4,8 @@ kind: GrafanaDashboard
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.labels" (dict "ctx" .) | nindent 4 }}
+    app.kubernetes.io/processed-by-operator: grafana-operator
 spec:
   json: >
     {

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/deployment.yaml
@@ -1,18 +1,15 @@
 {{- if and .Values.install (not .Values.asDaemonSet) }}
+{{- $name := .Values.name -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}
+  name: {{ $name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
-    {{- if .Values.labels }}
-      {{- toYaml .Values.labels | nindent 4 }}
-    {{- end }}
+    {{- include "monitoring.labels" . | nindent 4 }}
+    app.kubernetes.io/instance: {{ cat $name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/version: {{ splitList ":" (include "blackboxExporter.image" .) | last }}
+    app.kubernetes.io/technology: go
+    {{- include "monitoring.extraLabels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
@@ -20,26 +17,22 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ .Values.name }}
+      app: {{ $name }}
   template:
     metadata:
       labels:
-        app: {{ .Values.name }}
-        app.kubernetes.io/name: {{ .Values.name }}
-        app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-        app.kubernetes.io/component: blackbox-exporter
-        app.kubernetes.io/part-of: monitoring
-        app.kubernetes.io/version: {{ splitList ":" $image | last }}
-        app.kubernetes.io/managed-by: Helm
-        {{- if .Values.labels }}
-          {{- toYaml .Values.labels | nindent 8 }}
-        {{- end }}
+        app: {{ $name }}
+        {{- include "monitoring.labels" . | nindent 8 }}
+        app.kubernetes.io/instance: {{ cat $name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
+        app.kubernetes.io/version: {{ splitList ":" (include "blackboxExporter.image" .) | last }}
+        app.kubernetes.io/technology: go
+        {{- include "monitoring.extraLabels" . | nindent 8 }}
       {{- if .Values.annotations }}
       annotations:
         {{- toYaml .Values.annotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ .Values.name }}
+      serviceAccountName: {{ $name }}
       securityContext:
         {{ include "blackboxExporter.securityContext" . }}
       {{- if .Values.tolerations }}
@@ -81,12 +74,12 @@ spec:
         - name: config
       {{- if .Values.secretConfig }}
           secret:
-            secretName: {{ .Values.name }}
+            secretName: {{ $name }}
       {{- else if .Values.configExistingSecretName }}
           secret:
             secretName: {{ .Values.configExistingSecretName }}
       {{- else }}
           configMap:
-            name: {{ .Values.name }}
+            name: {{ $name }}
 {{- end }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/service.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/service.yaml
@@ -4,12 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/serviceaccount.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/serviceaccount.yaml
@@ -4,10 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.name }}
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-    app.kubernetes.io/instance: {{ cat .Values.name "-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: blackbox-exporter
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.labels" . | nindent 4 }}
 {{- end -}}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor-self.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor-self.yaml
@@ -1,14 +1,11 @@
+{{- $name := .Values.name -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: blackbox-exporter
+  name: {{ $name }}
   labels:
-    app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/instance: {{ cat "blackbox-exporter-self-service-monitor-" .Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" . }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.labels" (dict "ctx" .) | nindent 4 }}
+    app.kubernetes.io/processed-by-operator: victoriametrics-operator
 spec:
   endpoints:
     - interval: {{ .Values.serviceMonitor.interval }}
@@ -16,10 +13,10 @@ spec:
       path: /metrics
       port: http
       scheme: {{ .Values.serviceMonitor.scheme }}
-  jobLabel: blackbox-exporter-self
+  jobLabel: {{ $name }}-self
   selector:
     matchExpressions:
       - key: app.kubernetes.io/name
         operator: In
         values:
-          - {{ .Values.name }}
+          - {{ $name }}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor-self.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor-self.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ $name }}
   labels:
-    {{- include "monitoring.labels" (dict "ctx" .) | nindent 4 }}
+    {{- include "monitoring.labels" . | nindent 4 }}
     app.kubernetes.io/processed-by-operator: victoriametrics-operator
 spec:
   endpoints:

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/templates/servicemonitor.yaml
@@ -1,17 +1,14 @@
 {{- if and .Values.install .Values.serviceMonitor.enabled }}
+{{- $name := .Values.name -}}
 {{- range .Values.serviceMonitor.targets }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ $.Values.name }}-{{ .name }}
+  name: {{ $name }}-{{ .name }}
   labels:
-    app.kubernetes.io/name: {{ $.Values.name }}-{{ .name }}
-    app.kubernetes.io/instance: {{ cat $.Values.name "-" .name "-" $.Release.Namespace | nospace | trunc 63 | trimSuffix "-" }}
-    app.kubernetes.io/component: monitoring
-    app.kubernetes.io/part-of: monitoring
-    {{- $image := include "blackboxExporter.image" $ }}
-    app.kubernetes.io/version: {{ splitList ":" $image | last }}
+    {{- include "monitoring.labels" (dict "ctx" $ "name" (printf "%s-%s" $.Values.name .name)) | nindent 4 }}
+    app.kubernetes.io/processed-by-operator: victoriametrics-operator
 spec:
   endpoints:
   - port: http
@@ -33,12 +30,12 @@ spec:
       - targetLabel: {{ $targetLabel }}
         replacement: {{ $replacement }}
         {{- end }}
-  jobLabel: {{ $.Values.name }}
+  jobLabel: {{ $name }}
   selector:
     matchExpressions:
       - key: app.kubernetes.io/name
         operator: In
         values:
-          - {{ $.Values.name }}
+          - {{ $name }}
 {{- end }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/charts/blackbox-exporter/values.yaml
+++ b/charts/qubership-monitoring-operator/charts/blackbox-exporter/values.yaml
@@ -10,7 +10,7 @@
 install: false
 
 # A name of a microservice to deploy with.
-# This name will be used as name of the microservice deployment and in labels.
+# Used for resource metadata.name and for app.kubernetes.io/name label.
 name: blackbox-exporter
 
 # A Docker image to deploy the blackbox-exporter.

--- a/charts/qubership-monitoring-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/templates/_helpers.tpl
@@ -5,7 +5,7 @@ Base resource labels: expects either chart context (.) or dict with ctx and opti
 When name or component are omitted, they are derived from ctx.Values (name, component|default name).
 Usage:
   {{- include "monitoring.labels" . | nindent 4 }}
-  Or with overrides: (dict "ctx" . "name" "x" "processedByOperator" "prometheus-operator")
+  Or with overrides: (dict "ctx" . "name" "x" "component" "y")
 */}}
 {{- define "monitoring.labels" -}}
 {{- $ctx := index . "ctx" | default . -}}
@@ -22,7 +22,7 @@ app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
 {{/*
 Extra labels helper: renders arbitrary labels map when provided.
 Usage:
-  {{- include "monitoring.extraLabels" (dict "extraLabels" .Values.labels) | nindent 4 }}
+  {{- include "monitoring.extraLabels" (dict "ctx" . "extraLabels" .Values.labels) | nindent 4 }}
 */}}
 {{- define "monitoring.extraLabels" -}}
 {{- $ctx := index . "ctx" | default . -}}

--- a/charts/qubership-monitoring-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/templates/_helpers.tpl
@@ -1,6 +1,40 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
+Base resource labels: expects either chart context (.) or dict with ctx and optional overrides.
+When name or component are omitted, they are derived from ctx.Values (name, component|default name).
+Usage:
+  {{- include "monitoring.labels" . | nindent 4 }}
+  Or with overrides: (dict "ctx" . "name" "x" "processedByOperator" "prometheus-operator")
+*/}}
+{{- define "monitoring.labels" -}}
+{{- $ctx := index . "ctx" | default . -}}
+{{- $vals := $ctx.Values -}}
+{{- $name := .name | default $vals.name -}}
+{{- $component := .component | default $ctx.Chart.Name -}}
+name: {{ $name }}
+app.kubernetes.io/name: {{ $name }}
+app.kubernetes.io/component: {{ $component }}
+app.kubernetes.io/part-of: monitoring
+app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
+{{- end -}}
+
+{{/*
+Extra labels helper: renders arbitrary labels map when provided.
+Usage:
+  {{- include "monitoring.extraLabels" (dict "extraLabels" .Values.labels) | nindent 4 }}
+*/}}
+{{- define "monitoring.extraLabels" -}}
+{{- $ctx := index . "ctx" | default . -}}
+{{- $vals := $ctx.Values -}}
+{{- $extra := .extraLabels | default ($vals.labels | default dict) -}}
+{{ with $extra }}
+
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Expand the name of the chart. This is suffixed with -alertmanager, which means subtract 13 from longest 63 available
 */}}
 {{- define "monitoring.name" -}}


### PR DESCRIPTION
- Root _helpers.tpl: monitoring.labels (ctx/optional overrides), monitoring.workloadLabels (values-driven)
- Blackbox-exporter: values-driven name/component/technology; workload labels via instance/version helpers; all resources use monitoring.labels or monitoring.workloadLabels; CRs set processedByOperator
