### PR TITLE
fix: go-test migration to new release

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -27,17 +27,18 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
+  packages: write
 jobs:
   test:
-    name: Build and test with coverage        
-    uses: Netcracker/qubership-core-infra/.github/workflows/go-build-with-sonar.yaml@6e420b55247f775963c3b18319a6bd62afa179ab #v1.3.0
+    name: Build and test with coverage
+    uses: Netcracker/qubership-core-infra/.github/workflows/generic-go-build.yaml@bc2a0bd082147e23b4091616c608a21cc2957728 # v2.4.1
     with:
       go-module-dir: '.'
-      actor: ${{ github.actor }}
       sonar-project-key: ${{ vars.SONAR_PROJECT_KEY }}
-      kube-version: '1.30.0'
-      envtest-version: 'release-0.19'
       cover-packages: './controllers/...,./api/...'
       install-envtest: true
-    secrets:
-      sonar-token: ${{ secrets.SONAR_TOKEN }}
+      kube-version: '1.30.0'
+      envtest-version: 'release-0.19'
+      skip-docker: true
+    secrets: inherit


### PR DESCRIPTION
Migrate go-test workflow to new release version