### PR TITLE
fix: remove static route from routes in vmuser cr

### DIFF
--- a/controllers/victoriametrics/vmuser/manifest.go
+++ b/controllers/victoriametrics/vmuser/manifest.go
@@ -129,9 +129,6 @@ func vmUser(cr *monv1.PlatformMonitoring) (*vmetricsv1b1.VMUser, error) {
 						Name:      "k8s",
 						Namespace: cr.GetNamespace(),
 					},
-					Static: &vmetricsv1b1.StaticRef{
-						URL: vmAlert.AsURL(),
-					},
 					Paths: vmAlertPaths(),
 				}
 				vmSPaths = vmSinglePaths()


### PR DESCRIPTION
# What does this PR do?

The config from the VMUser CR can't be applied with `vm-operator` version `v0.68.1`.

```bash
status:
  reason: >-
    targetRef validation failed, one of `crd` or `static` must be configured,
    got both for users[1]
  updateStatus: failed
```

## Root cause

In the VMUser CR, we have a config:

```yaml
    - crd:
        kind: VMAlert
        name: k8s
        namespace: monitoring
      paths:
        - /api/v1/rules
        - /api/v1/alerts
        - /api/v1/alert.*
        - /vmalert.*
      static:
        url: http://vmalert-k8s.monitoring.svc:8080
```

That fails validation in vm-operator and doesn't allow it to apply the configuration to VMAuth.

## Solution

Need to remove the `static` route and use routing by CRD.

## How was it tested?

Deployed in Kubernetes and validated that the VMUser config applied to VMAuth, and I can use BasicAuth to open the UI.