### PR TITLE
feat: add a simple tool to update operators CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CRDS_DIR=$(BUILD_DIR)/_crds
 
 # CRDs inside the subcharts
 MON_CRD_FOLDER=$(HELM_FOLDER)/crds
-GRAFANA_CRD_FODLER=$(HELM_FOLDER)/charts/grafana-operator/crds
+GRAFANA_CRD_FOLDER=$(HELM_FOLDER)/charts/grafana-operator/crds
 PROM_OPER_CRD_FOLDER=$(HELM_FOLDER)/charts/prometheus-operator/crds
 PROM_ADAPTER_CRD_FOLDER=$(HELM_FOLDER)/charts/prometheus-adapter-operator/crds
 VM_CRD_FOLDER=$(HELM_FOLDER)/charts/victoriametrics-operator/crds
@@ -77,6 +77,14 @@ pkgs = $(shell go list ./... | grep -v /test/envtests)
 CONTAINER_CLI?=docker
 CONTAINER_NAME="qubership-monitoring-operator"
 DOCKERFILE=Dockerfile
+
+# CRD update tool and operator versions (override on the command line, e.g.
+# `make update-prometheus-crds PROMETHEUS_OPERATOR_VERSION=0.90.1`)
+CRD_UPDATE_TOOL=tools/crd-update/crd-update.py
+PYTHON?=python3
+PROMETHEUS_OPERATOR_VERSION?=0.90.1
+VICTORIAMETRICS_OPERATOR_VERSION?=0.66.0
+GRAFANA_OPERATOR_VERSION?=5.21.0
 
 ###########
 # Generic #
@@ -203,7 +211,7 @@ docs/crd/v1:
 	echo "=> Copy CRDs from charts to documentation ..."
 	rm -rf $(CRD_DOC_FOLDER)/*.yaml
 	cp $(MON_CRD_FOLDER)/* $(CRD_DOC_FOLDER)/
-	cp $(GRAFANA_CRD_FODLER)/* $(CRD_DOC_FOLDER)/
+	cp $(GRAFANA_CRD_FOLDER)/* $(CRD_DOC_FOLDER)/
 	cp $(PROM_OPER_CRD_FOLDER)/* $(CRD_DOC_FOLDER)/
 	cp $(PROM_ADAPTER_CRD_FOLDER)/* $(CRD_DOC_FOLDER)/
 	cp $(VM_CRD_FOLDER)/* $(CRD_DOC_FOLDER)/
@@ -217,6 +225,42 @@ docs/crd/v1:
 update-crds:
 	echo "=> Update CRDs in dedicated Helm chart ..."
 	find $(CRD_DOC_FOLDER) \( -name "*.yaml" -o -name "*.yml" \) -exec cp {} ${CRDS_HELM_CRDS_FOLDER}/crds/ \;
+
+###############
+# CRD update #
+###############
+
+# Download upstream CRDs for managed operators and write them into the
+# corresponding subchart `crds/` folders. Versions can be overridden via
+# PROMETHEUS_OPERATOR_VERSION / VICTORIAMETRICS_OPERATOR_VERSION /
+# GRAFANA_OPERATOR_VERSION variables.
+# Note: Grafana CRDs are not updated currently because we are using old version of the operator.
+.PHONY: update-operators-crds
+update-operators-crds: update-prometheus-crds update-victoriametrics-crds
+
+.PHONY: update-prometheus-crds
+update-prometheus-crds:
+	echo "=> Update prometheus-operator CRDs (v$(PROMETHEUS_OPERATOR_VERSION)) ..."
+	$(PYTHON) $(CRD_UPDATE_TOOL) \
+		--operator prometheus \
+		--version $(PROMETHEUS_OPERATOR_VERSION) \
+		--output-dir $(PROM_OPER_CRD_FOLDER)
+
+.PHONY: update-victoriametrics-crds
+update-victoriametrics-crds:
+	echo "=> Update victoriametrics-operator CRDs (v$(VICTORIAMETRICS_OPERATOR_VERSION)) ..."
+	$(PYTHON) $(CRD_UPDATE_TOOL) \
+		--operator victoriametrics \
+		--version $(VICTORIAMETRICS_OPERATOR_VERSION) \
+		--output-dir $(VM_CRD_FOLDER)
+
+.PHONY: update-grafana-crds
+update-grafana-crds:
+	echo "=> Update grafana-operator CRDs (v$(GRAFANA_OPERATOR_VERSION)) ..."
+	$(PYTHON) $(CRD_UPDATE_TOOL) \
+		--operator grafana \
+		--version $(GRAFANA_OPERATOR_VERSION) \
+		--output-dir $(GRAFANA_CRD_FOLDER)
 
 ###################
 # Running locally #

--- a/tools/crd-update/README.md
+++ b/tools/crd-update/README.md
@@ -1,0 +1,29 @@
+# CRD Update
+
+## CLI
+
+```bash
+python crd-update.py --operator {prometheus,victoriametrics,grafana} --version xxx --output-dir path/to/output
+```
+
+## Logic
+
+- Download: builds the GitHub release URL from a per-operator template (bundle.yaml / crd.yaml / crds.yaml).
+- Sanitize: replaces smart quotes (incl. U+201D ”), en/em dashes, ellipsis, NBSP — runs on the raw text before YAML parsing so malformed
+descriptions don't crash the loader.
+- Split: iterates all docs, keeps only kind: CustomResourceDefinition, and writes one file per CRD as <group>_<plural>.yaml.
+
+Add next annotations:
+
+- Always adds `helm.sh/hook: crd-install` and `helm.sh/hook-weight: "-5"`
+- For VictoriaMetrics adds `operator.victoriametrics.com/version: <version>`
+- For Grafana adds `operator.grafana.com/version: <version>`
+- For Prometheus, leaves the existing `operator.prometheus.io/version` alone since it already ships in the bundle
+
+## Usage examples
+
+```bash
+python crd-update.py -o victoriametrics -v 0.69.0 -d output/vm
+python crd-update.py -o prometheus     -v 0.90.1 -d output/prom
+python crd-update.py -o grafana        -v 5.22.2 -d output/grafana
+```

--- a/tools/crd-update/crd-update.py
+++ b/tools/crd-update/crd-update.py
@@ -1,0 +1,137 @@
+import argparse
+import io
+import logging
+import os
+import sys
+import urllib.request
+
+from ruamel.yaml import YAML
+
+
+log = logging.getLogger("crd-update")
+
+
+OPERATORS = {
+    "prometheus": {
+        "url": "https://github.com/prometheus-operator/prometheus-operator/releases/download/v{version}/bundle.yaml",
+        "version_annotation": None,  # already present in CRDs
+    },
+    "victoriametrics": {
+        "url": "https://github.com/VictoriaMetrics/operator/releases/download/v{version}/crd.yaml",
+        "version_annotation": "operator.victoriametrics.com/version",
+    },
+    "grafana": {
+        "url": "https://github.com/grafana/grafana-operator/releases/download/v{version}/crds.yaml",
+        "version_annotation": "operator.grafana.com/version",
+    },
+}
+
+# Map of common non-UTF-8 / "smart" characters that appear in CRD descriptions
+# and break YAML parsers or downstream tooling. Replace with safe ASCII equivalents.
+CHAR_REPLACEMENTS = {
+    "‘": "'",   # left single quotation mark
+    "’": "'",   # right single quotation mark
+    "“": '"',   # left double quotation mark
+    "”": '"',   # right double quotation mark
+    "–": "-",   # en dash
+    "—": "-",   # em dash
+    "…": "...", # horizontal ellipsis
+    " ": " ",   # non-breaking space
+}
+
+HELM_HOOK_ANNOTATIONS = {
+    "helm.sh/hook": "crd-install",
+    "helm.sh/hook-weight": "-5",
+}
+
+
+def download(url):
+    log.info("Downloading %s", url)
+    with urllib.request.urlopen(url) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def sanitize(text):
+    for bad, good in CHAR_REPLACEMENTS.items():
+        text = text.replace(bad, good)
+    return text
+
+
+def ensure_annotations(doc, extra_annotations):
+    metadata = doc.setdefault("metadata", {})
+    annotations = metadata.get("annotations") or {}
+    for key, value in extra_annotations.items():
+        annotations[key] = value
+    metadata["annotations"] = annotations
+
+
+def filename_for(crd):
+    group = crd["spec"]["group"].lower()
+    plural = crd["spec"]["names"]["plural"].lower()
+    return f"{group}_{plural}.yaml"
+
+
+def process(operator, version, output_dir):
+    spec = OPERATORS[operator]
+    url = spec["url"].format(version=version)
+    raw = sanitize(download(url))
+
+    yaml = YAML()
+    yaml.width = 4096
+    yaml.preserve_quotes = True
+
+    docs = list(yaml.load_all(io.StringIO(raw)))
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    written = 0
+    for doc in docs:
+        if not doc:
+            continue
+        if doc.get("kind", "").lower() != "customresourcedefinition":
+            continue
+
+        annotations = dict(HELM_HOOK_ANNOTATIONS)
+        if spec["version_annotation"]:
+            annotations[spec["version_annotation"]] = version
+        ensure_annotations(doc, annotations)
+
+        out_path = os.path.join(output_dir, filename_for(doc))
+        with open(out_path, "w", encoding="utf-8") as f:
+            yaml.dump(doc, f)
+        log.info("Wrote %s", out_path)
+        written += 1
+
+    if written == 0:
+        log.warning("No CRDs found in %s", url)
+    else:
+        log.info("Wrote %d CRD(s) for %s %s into %s", written, operator, version, output_dir)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-5s[%(name)s] - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    parser = argparse.ArgumentParser(description="Download and prepare operator CRDs for Helm packaging.")
+    parser.add_argument("--operator", "-o", required=True, choices=sorted(OPERATORS.keys()),
+                        help="Operator whose CRDs to fetch. Available values: prometheus, victoriametrics, grafana.")
+    parser.add_argument("--version", "-v", required=True,
+                        help="Operator release version (without leading 'v', e.g. 0.90.1)")
+    parser.add_argument("--output-dir", "-d", default="output",
+                        help="Directory to write split CRD files into")
+
+    args = parser.parse_args()
+    version = args.version.lstrip("v")
+
+    try:
+        process(args.operator, version, args.output_dir)
+    except Exception as e:
+        log.error("Failed: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/crd-update/crd-update.py
+++ b/tools/crd-update/crd-update.py
@@ -29,14 +29,14 @@ OPERATORS = {
 # Map of common non-UTF-8 / "smart" characters that appear in CRD descriptions
 # and break YAML parsers or downstream tooling. Replace with safe ASCII equivalents.
 CHAR_REPLACEMENTS = {
-    "‘": "'",   # left single quotation mark
-    "’": "'",   # right single quotation mark
-    "“": '"',   # left double quotation mark
-    "”": '"',   # right double quotation mark
-    "–": "-",   # en dash
-    "—": "-",   # em dash
-    "…": "...", # horizontal ellipsis
-    " ": " ",   # non-breaking space
+    "‘": "'",    # left single quotation mark
+    "’": "'",    # right single quotation mark
+    "“": '"',    # left double quotation mark
+    "”": '"',    # right double quotation mark
+    "–": "-",    # en dash
+    "—": "-",    # em dash
+    "…": "...",  # horizontal ellipsis
+    " ": " ",    # non-breaking space
 }
 
 HELM_HOOK_ANNOTATIONS = {

--- a/tools/crd-update/requirements.txt
+++ b/tools/crd-update/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.14.0
+argparse>=1.2.1


### PR DESCRIPTION
# What does PR do?

It adds a simple Python tool that should significantly simplify CRDs updates for all operators we use for monitoring.

Usage:

```bash
python crd-update.py -o victoriametrics -v 0.69.0 -d /path/to/output
```