### PR TITLE
fix: change env using in github action for alerts unit-tests

### DIFF
--- a/.github/workflows/test-alert-rules-unit-tests.yaml
+++ b/.github/workflows/test-alert-rules-unit-tests.yaml
@@ -1,5 +1,5 @@
 ---
-name: Test Alert Rules Unit Tests
+name: "Tests: Alert rules unit-tests"
 
 on:
   workflow_run:
@@ -17,7 +17,7 @@ env:
   vmalert_tool_version: v1.142.0
   tests_dir: test/alerts-tests
   source_alert_rules_file: controllers/prometheus-rules/assets/prometheus-rules.yaml
-  target_alert_rules_file: ${tests_dir}/rules.yaml
+  target_alert_rules_file: test/alerts-tests/rules.yaml
 
 jobs:
   Run-Alerts-Test:
@@ -27,32 +27,26 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: 'latest'
-
       - name: Install vmalert-tool
         run: |
-          wget --max-redirect=0 -q https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${vmalert_tool_version}/vmutils-linux-amd64-${vmalert_tool_version}.tar.gz
-          tar -xvf vmutils-linux-amd64-${vmalert_tool_version}.tar.gz
+          wget --max-redirect=0 -q https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${{ env.vmalert_tool_version }}/vmutils-linux-amd64-${{ env.vmalert_tool_version }}.tar.gz
+          tar -xvf vmutils-linux-amd64-${{ env.vmalert_tool_version }}.tar.gz
           mv vmalert-tool-prod vmalert-tool
           chmod +x vmalert-tool
 
       - name: Render rules file from assets
         run: |
           echo "Alert rules are detected in assets, use them for test and ignore others"
-          cp ${source_alert_rules_file} ${target_alert_rules_file}
-          sed '1,11d' -i ${target_alert_rules_file}
+          cp ${{ env.source_alert_rules_file }} ${{ env.target_alert_rules_file }}
+          sed '1,11d' -i ${{ env.target_alert_rules_file }}
 
       - name: Check count of test cases for each alert rule
         run: |
-          chmod +x ./${tests_dir}/tests-checker.sh
-          ./${tests_dir}/tests-checker.sh
+          chmod +x ./${{ env.tests_dir }}/tests-checker.sh
+          ./${{ env.tests_dir }}/tests-checker.sh
         continue-on-error: true
 
       - name: Run test
         run: |
-          FILES=$(find ${tests_dir} -name "*-tests.yaml" | sort | sed 's/^/--file /' | tr '\n' ' ')
+          FILES=$(find ${{ env.tests_dir }} -name "*-tests.yaml" | sort | sed 's/^/--file /' | tr '\n' ' ')
           ./vmalert-tool unittest ${FILES}
-


### PR DESCRIPTION
# What does this PR do?

GitHub Action to run alerts unit-tests failed with the error:

```bash
Run wget --max-redirect=0 -q https://github.com/VictoriaMetrics/VictoriaMetrics/releases/download/${vmalert_tool_version}/vmutils-linux-amd64-${vmalert_tool_version}.tar.gz
Error: Process completed with exit code 8.
```

## Solution

Fix how this alert unit tests GitHub Action works with the env inside the action.