### PR TITLE
fix: add support grafana-operator v5 status support in integration tests

### DIFF
--- a/test/robot-tests/src/lib/CheckJsonObject.py
+++ b/test/robot-tests/src/lib/CheckJsonObject.py
@@ -115,11 +115,53 @@ def get_list_length(list_for_check):
 
 
 def get_dashboard_from_status(dictionary, namespace, name):
-    status = dictionary.get('status')
-    dashboards = status.get('dashboards')
+    # grafana-operator v5 emits status.dashboards as a list of strings of the
+    # form "<namespace>/<name>/<uid>" (v4 used a list of dicts with explicit
+    # namespace/name/uid keys). Normalize both shapes to a dict so callers
+    # can keep using .get('uid'), .get('namespace'), .get('name').
+    status = dictionary.get('status') or {}
+    dashboards = status.get('dashboards') or []
     for i in dashboards:
-        if (i.get('namespace') == namespace) and (i.get('name') == name):
-            return i
+        if isinstance(i, dict):
+            if i.get('namespace') == namespace and i.get('name') == name:
+                return i
+            continue
+        if isinstance(i, str):
+            parts = i.split('/')
+            if len(parts) >= 2 and parts[0] == namespace and parts[1] == name:
+                uid = parts[2] if len(parts) >= 3 else None
+                return {'namespace': namespace, 'name': name, 'uid': uid}
+    return None
+
+
+def is_resource_ready_from_conditions(obj):
+    """True iff the resource is in a ready/success state.
+
+    Checks the grafana-operator v5 schema first (status.conditions[] with at
+    least one entry whose status == "True"), then falls back to the v4 schema
+    (status.message == "success") for backward compatibility.
+    """
+    status = (obj or {}).get('status') or {}
+    for cond in status.get('conditions') or []:
+        if str(cond.get('status')) == 'True':
+            return True
+    if status.get('message') == 'success':
+        return True
+    return False
+
+
+def is_grafana_cr_ready(obj):
+    """True iff the Grafana CR reports success.
+
+    v5: status.stageStatus == "success" (with status.stage == "complete").
+    v4 fallback: status.message == "success".
+    """
+    status = (obj or {}).get('status') or {}
+    if status.get('stageStatus') == 'success':
+        return True
+    if status.get('message') == 'success':
+        return True
+    return False
 
 
 def parse_yaml_file(file_path):

--- a/test/robot-tests/src/tests/grafana/keywords.robot
+++ b/test/robot-tests/src/tests/grafana/keywords.robot
@@ -71,9 +71,16 @@ Get Dashboard In Namespace
 Check That Dashboard Created Successfuly
     [Arguments]   ${dashboard_name}  ${namespace}
     ${object}=  Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
-    ...  Check Resource Status Success in Cloud  ${namespace}  grafanadashboards  ${dashboard_name}
-    ${status}=   Set Variable  ${object.get("status")}
-    Run Keyword If  ${status} != None  Should Be Equal As Strings  ${status.get('message')}   success
+    ...  Check Dashboard Ready In Cloud  ${namespace}  ${dashboard_name}
+    RETURN  ${object}
+
+Check Dashboard Ready In Cloud
+    [Arguments]  ${namespace}  ${dashboard_name}
+    ${object}=  Check Resource Status Success in Cloud  ${namespace}  grafanadashboards  ${dashboard_name}
+    # Check v5 (status.conditions[].status == True) first, fall back to v4
+    # (status.message == "success") for backward compatibility.
+    ${ready}=  Is Resource Ready From Conditions  ${object}
+    Should Be True  ${ready}  GrafanaDashboard ${dashboard_name} is not ready (no v5 condition with status=True and no v4 status.message=success)
     RETURN  ${object}
 
 Check Resource Status Success in Cloud
@@ -85,16 +92,18 @@ Check Resource Status Success in Cloud
 
 Check That Grafana CR Includes Test Dashboard
     [Arguments]   ${dashboard_name}  ${namespace}
-    ${object}=  Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
+    ${dashboard_status}=  Wait Until Keyword Succeeds  ${RETRY_TIME}  ${RETRY_INTERVAL}
     ...  Check Status Of Dashboards Includes Name, Namespace  ${namespace}  ${dashboard_name}
-    ${status}=   Set Variable  ${object.get("status")}
-    Run Keyword If  ${status} != None  Should Be Equal As Strings  ${status.get('message')}  success
-    RETURN  ${object}
+    RETURN  ${dashboard_status}
 
 Check Status Of Dashboards Includes Name, Namespace
     [Arguments]  ${namespace}  ${name}
-    ${grafana_CR_status}=   Check Resource Status Success in Cloud  ${namespace}  grafanas  grafana
-    ${dashboard_status}=  Get Dashboard From Status  ${grafana_CR_status}  ${namespace}  ${name}
+    ${grafana_CR}=   Check Resource Status Success in Cloud  ${namespace}  grafanas  grafana
+    # v5: status.stageStatus == "success" (with status.stage == "complete").
+    # v4 fallback: status.message == "success".
+    ${ready}=  Is Grafana CR Ready  ${grafana_CR}
+    Should Be True  ${ready}  Grafana CR is not ready (no v5 status.stageStatus=success and no v4 status.message=success)
+    ${dashboard_status}=  Get Dashboard From Status  ${grafana_CR}  ${namespace}  ${name}
     Run Keyword If  ${dashboard_status} == None
     ...  Fail  Error! Dashboard with following name not found in namespace
     RETURN  ${dashboard_status}


### PR DESCRIPTION
# What does this PR do?

Integration tests failed after merging the PR to upgrade grafana-operator to v5.x with errors like:

```bash
Tests.Grafana.Simple Test                                                     
==============================================================================
Verify Login To Grafana                                               | PASS |
------------------------------------------------------------------------------
Create Object Grafana Dashboard                                       | FAIL |
None != success
------------------------------------------------------------------------------
Update GrafanaDashboard And Check It Updated                          | PASS |
------------------------------------------------------------------------------
Delete Dashboard And Check It Deleted In Grafana                      | PASS |
------------------------------------------------------------------------------
Tests.Grafana.Simple Test                                             | FAIL |
4 tests, 3 passed, 1 failed
==============================================================================
Tests.Grafana                                                         | FAIL |
4 tests, 3 passed, 1 failed
```

This issue occurs because in grafana-operator v5.x, the status of `Grafana` CR changed.

v4.10.1:
```yaml
status:
  dashboards:
    - folderId: 1898981484650496
      folderName: logging
      hash: 235367cf94694374e696974161a197645338d5053d5cd664dc1daca30015c8aa
      name: fluentbit-metrics-v1
      namespace: logging
      uid: d261b9387b863ec2bad527481a89c070b8bc7050
  message: success
  phase: reconciling
  previousServiceName: grafana-service
```

v5.x:
```yaml
status:
  adminUrl: http://grafana-service.monitoring.svc:3000
  conditions:
    - lastTransitionTime: '2026-04-23T14:43:28Z'
      message: Grafana reconcile completed
      observedGeneration: 1
      reason: GrafanaReady
      status: 'True'
      type: GrafanaReady
  contactPoints:
    - monitoring/notification-test/Email Test
  dashboards:
    - monitoring/core-dns-dashboard/monitoring-core-dns
  datasources:
    - >-
      monitoring/platform-monitoring-prometheus/151e4d75-d407-4fea-b331-113884688f3e
  folders:
    - monitoring/folder-test/fdb35601-b9f2-4d3a-bb38-4fdf6e1d5a78
  stage: complete
  stageStatus: success
  version: 12.3.5
```

## Solution

Update integration tests to read both types of statuses:
- firstly, try to read the v5 status
- fallback to 4.x if v5 status is absent 