### PR TITLE
chore: change actions conditions to run to stop run them twice

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,9 @@ on:
     types: [created]
   push:
     branches:
-    - '**'
+    - main
+    tags:
+    - 'v*'
     paths:
     - '**'
     - '!.github/**'

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,6 +1,10 @@
 name: Go test with Sonar
 on:
-  push: {}
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -14,7 +14,9 @@ name: Lint Code Base
 on:
   push:
     branches:
-      - '**'
+      - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
# What does this PR do?

Many GitHub Actions run twice for each PR, like build, lint, etc. 

## Solution

Adjust conditions to run GitHub Actions.