### PR TITLE
fix: update apiVersion and add instanceSelector to alerts-overview dashboard

### DIFF
--- a/controllers/grafana-operator/assets/grafana-dashboards/alerts-overview.yaml
+++ b/controllers/grafana-operator/assets/grafana-dashboards/alerts-overview.yaml
@@ -1,10 +1,14 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: alertmanager-overview
+  name: alerts-overview
   labels:
     app.kubernetes.io/component: monitoring
 spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/part-of: monitoring
   json: >
     {
       "annotations": {


### PR DESCRIPTION
# What does this PR do?

The monitoring-operator can't run the deployment of Grafana due to the error:

```json
{"level":"ERROR","time":"2026-05-14T16:13:24.316","logger":"controller-platformmonitoring","message":"Reconciliation of grafana-operator failed","error":"GrafanaDashboard.grafana.integreatly.org \"alertmanager-overview\" is invalid: [spec.instanceSelector: Required value, <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]"}
``` 

During the merging of the PR with changes in "Alerts - Overview," merge changes were executed incorrectly, so `apiVersion` and `kind` returned to old values.

## Solution

Need to update CR to the new API and change its name to correct.