### PR TITLE
fix: change dockerfile to restore docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ pkgs = $(shell go list ./... | grep -v /test/envtests)
 # Container name
 CONTAINER_CLI?=docker
 CONTAINER_NAME="qubership-monitoring-operator"
-DOCKERFILE=Dockerfile
+DOCKERFILE=cmd/operator/Dockerfile
 
 ###########
 # Generic #

--- a/cmd/etcd-certs-to-secret/main.go
+++ b/cmd/etcd-certs-to-secret/main.go
@@ -22,10 +22,10 @@ const (
 	etcdSourceConfigmapOpenshiftV4 = "etcd-metric-serving-ca"
 	etcdSourceSecretOpenshiftV4    = "etcd-metric-client"
 
-	etcdServiceName                = "etcd"
-	etcdServiceNamespace           = "kube-system"
-	etcdPodLabelSelector           = "component=etcd"
-	openshiftSecurityAPIGroup      = "security.openshift.io"
+	etcdServiceName           = "etcd"
+	etcdServiceNamespace      = "kube-system"
+	etcdPodLabelSelector      = "component=etcd"
+	openshiftSecurityAPIGroup = "security.openshift.io"
 )
 
 type appOptions struct {

--- a/cmd/etcd-certs-to-secret/main_test.go
+++ b/cmd/etcd-certs-to-secret/main_test.go
@@ -74,13 +74,13 @@ func TestNewLoggerDefaultsToInfoWhenConfigured(t *testing.T) {
 
 func TestParseOptions(t *testing.T) {
 	tests := []struct {
-		name        string
-		args        []string
-		env         map[string]string
-		wantNS      string
-		wantSecret  string
-		wantLevel   slog.Level
-		wantErr     bool
+		name       string
+		args       []string
+		env        map[string]string
+		wantNS     string
+		wantSecret string
+		wantLevel  slog.Level
+		wantErr    bool
 	}{
 		{
 			name:       "defaults fall back to monitoring",

--- a/controllers/grafana/manifest.go
+++ b/controllers/grafana/manifest.go
@@ -531,7 +531,7 @@ func grafanaDataSource(cr *monv1.PlatformMonitoring, KubeClient kubernetes.Inter
 				maps.Copy(vmCluster.Spec.VMSelect.ExtraArgs, map[string]string{"tls": "true"})
 			}
 			if dataSource.Spec.Datasource != nil {
-				dataSource.Spec.Datasource.URL =  vmCluster.AsURL(vmetricsv1b1.ClusterComponentSelect) + "/select/0/prometheus"
+				dataSource.Spec.Datasource.URL = vmCluster.AsURL(vmetricsv1b1.ClusterComponentSelect) + "/select/0/prometheus"
 			}
 		}
 		if cr.Spec.Victoriametrics.VmAgent.IsInstall() && len(strings.TrimSpace(cr.Spec.Victoriametrics.VmAgent.ScrapeInterval)) > 0 {


### PR DESCRIPTION
# What does this PR do?

Fix the path to the monitoring-operator Dockerfile in Makefile.

The place for the operator's Dockerfile changed in PR: https://github.com/Netcracker/qubership-monitoring-operator/pull/348

## Additional changes

Apply `go vet` and `go fmt` to Go files. They run as a part of the Makefile for the `build` task.