### PR TITLE
fix: add logic to update active targets in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,31 +1,34 @@
-name: Run Monitoring Pipeline
+name: 'Tests: Run monitoring integration tests'
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+    tags:
+      - v*
     paths:
-    - '**'
-    - '!.github/**'
-    - '.github/workflows/integration-tests.yaml'
-    - '!docs/**'
-    - '!CODE-OF-CONDUCT.md'
-    - '!CONTRIBUTING.md'
-    - '!LICENSE'
-    - '!README.md'
-    - '!SECURITY.md'
+      - .github/workflows/integration-tests.yaml
+      - .github/expected-vm-cr-statuses.json
+      - api/**
+      - charts/**
+      - cmd/**
+      - controllers/**
+      - test/robot-tests/**
   pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
+    branches:
+      - '**'
+    types:
+      - opened
+      - synchronize
+      - reopened
     paths:
-    - '**'
-    - '!.github/**'
-    - '.github/workflows/integration-tests.yaml'
-    - '!docs/**'
-    - '!CODE-OF-CONDUCT.md'
-    - '!CONTRIBUTING.md'
-    - '!LICENSE'
-    - '!README.md'
-    - '!SECURITY.md'
+      - .github/workflows/integration-tests.yaml
+      - .github/expected-vm-cr-statuses.json
+      - api/**
+      - charts/**
+      - cmd/**
+      - controllers/**
+      - test/robot-tests/**
   workflow_dispatch: {}
 
 permissions:
@@ -63,6 +66,6 @@ jobs:
     uses: Netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@247c69038e00f2a9e283412e902555f84b16dab2 # v1.8.0
     with:
       service_branch: ${{ github.sha }}
-      pipeline_branch: '5e867049c9bc60651f53611cdcf167dc0c7f8ff4' #this value must match the value after '@' in 'uses'
+      pipeline_branch: '5e867049c9bc60651f53611cdcf167dc0c7f8ff4' # this value must match the value after '@' in 'uses'
       repository_name: '${{ github.repository_owner }}/qubership-monitoring-operator'
       kind-layout: 'single-node'

--- a/test/robot-tests/src/lib/CheckJsonObject.py
+++ b/test/robot-tests/src/lib/CheckJsonObject.py
@@ -14,11 +14,13 @@ def get_object_data(response):
 def get_prometheus_target(response, target_name):
     json_object = get_object_data(response)
     matched_targets = [
-        item for item in json_object.get('activeTargets', []) 
+        item for item in json_object.get('activeTargets', [])
         if target_name in item.get('labels', {}).get('job', '')
     ]
+
     def get_path(target):
         return urlparse(target.get("scrapeUrl", "")).path
+
     for target in matched_targets:
         if get_path(target) == "/probe":
             return target

--- a/test/robot-tests/src/lib/ConfigurationsStreamerLib.py
+++ b/test/robot-tests/src/lib/ConfigurationsStreamerLib.py
@@ -56,7 +56,7 @@ class ConfigurationsStreamerLib:
         self.ip_ftp_server = self._get_variable("${IP_FTP_SERVER}")
         self.ssh_key = self._get_variable("${SSH_KEY}")
         self.ftp_vm_user = self._get_variable("${FTP_VM_USER}")
-        
+
         self.grafana_basic_url = f"https://{self.ip_grafana_creds}/grafana"
         self.grafana_org_url = f"https://{self.ip_grafana_token}/grafana"
         self.grafana_org_token = ""
@@ -89,7 +89,8 @@ class ConfigurationsStreamerLib:
         self.built_in.log("Grafana Org Token has been set.", level="INFO")
 
     def get_cloud_dashboards(self, use_cr_name=False):
-        """Retrieves the list of dashboards from the cloud. Uses CR name (metadata.name) if use_cr_name=True, otherwise title."""
+        """Retrieves the list of dashboards from the cloud. Uses CR name (metadata.name)
+        if use_cr_name=True, otherwise title."""
         try:
             dashboards_cr = self.custom_api.list_cluster_custom_object(
                 group=self.DASHBOARD_GROUP,
@@ -129,7 +130,8 @@ class ConfigurationsStreamerLib:
     def compare_dashboards(self):
         """Compares dashboards between the cloud and two Grafana instances."""
         cloud_dashboards = self.get_cloud_dashboards()
-        basic_dashboards = self.get_grafana_dashboards(self.grafana_basic_url, auth=(self.grafana_basic_user, self.grafana_basic_pass))
+        basic_dashboards = self.get_grafana_dashboards(
+            self.grafana_basic_url, auth=(self.grafana_basic_user, self.grafana_basic_pass))
         org_dashboards = self.get_grafana_dashboards(self.grafana_org_url, token=self.grafana_org_token)
 
         missing_in_basic = set(cloud_dashboards) - set(basic_dashboards)
@@ -144,15 +146,17 @@ class ConfigurationsStreamerLib:
         """Checks that all dashboards are available in Grafana."""
         result = self.compare_dashboards()
         missing_messages = []
-        
+
         if result["missing_in_basic"]:
-            missing_messages.append(f"Missing in Grafana (Basic Auth) {self.grafana_basic_url}: {', '.join(result['missing_in_basic'])}")
+            missing_messages.append(
+                f"Missing in Grafana (Basic Auth) {self.grafana_basic_url}: {', '.join(result['missing_in_basic'])}")
         if result["missing_in_org"]:
-            missing_messages.append(f"Missing in Grafana (Org Token) {self.grafana_org_url}: {', '.join(result['missing_in_org'])}")
-        
+            missing_messages.append(
+                f"Missing in Grafana (Org Token) {self.grafana_org_url}: {', '.join(result['missing_in_org'])}")
+
         if missing_messages:
             self.built_in.fail("\n".join(missing_messages))
-        
+
         self.built_in.log("All dashboards are available in external Grafana.", level="INFO")
         return "All dashboards are available."
 
@@ -166,7 +170,8 @@ class ConfigurationsStreamerLib:
                 plural=self.DASHBOARD_PLURAL,
                 body=body
             )
-            self.built_in.log(f"Dashboard {body['metadata']['name']} created successfully in namespace {namespace}.", level="INFO")
+            self.built_in.log(
+                f"Dashboard {body['metadata']['name']} created successfully in namespace {namespace}.", level="INFO")
         except Exception as e:
             self.built_in.fail(f"Error creating dashboard in namespace {namespace}: {e}")
 
@@ -197,7 +202,8 @@ class ConfigurationsStreamerLib:
                 body=dashboard
             )
 
-            self.built_in.log(f"Dashboard '{dashboard_name}' updated successfully with new title '{new_title}'.", level="INFO")
+            self.built_in.log(
+                f"Dashboard '{dashboard_name}' updated successfully with new title '{new_title}'.", level="INFO")
 
         except Exception as e:
             self.built_in.fail(f"Error updating dashboard '{dashboard_name}': {e}")
@@ -212,13 +218,15 @@ class ConfigurationsStreamerLib:
                 plural=self.DASHBOARD_PLURAL,
                 name=dashboard_name
             )
-            self.built_in.log(f"Dashboard {dashboard_name} deleted successfully from namespace {namespace}.", level="INFO")
+            self.built_in.log(
+                f"Dashboard {dashboard_name} deleted successfully from namespace {namespace}.", level="INFO")
         except Exception as e:
             self.built_in.fail(f"Error deleting dashboard {dashboard_name} in namespace {namespace}: {e}")
 
     def check_dashboard_existence(self, title):
         """Checks if a specific Grafana Dashboard exists in external Grafana instances."""
-        basic_dashboards = self.get_grafana_dashboards(self.grafana_basic_url, auth=(self.grafana_basic_user, self.grafana_basic_pass))
+        basic_dashboards = self.get_grafana_dashboards(
+            self.grafana_basic_url, auth=(self.grafana_basic_user, self.grafana_basic_pass))
         org_dashboards = self.get_grafana_dashboards(self.grafana_org_url, token=self.grafana_org_token)
 
         missing_in_basic = title not in basic_dashboards
@@ -255,12 +263,12 @@ class ConfigurationsStreamerLib:
         ssh_client = self._create_ssh_connection(self.ip_ftp_server)
         ftp_dashboards = {}
         missing_paths = []
-        
+
         try:
             for path in self.FTP_PATHS:
                 command = f"ls {path} 2>/dev/null"
                 status, output = self._execute_command_on_vm(ssh_client, command)
-                
+
                 if status == 0 and output.strip():
                     files = [f.split("]")[-1] for f in output.strip().split("\n")]
                     ftp_dashboards[path] = files
@@ -269,27 +277,29 @@ class ConfigurationsStreamerLib:
                     missing_paths.append(path)
         finally:
             ssh_client.close()
-        
+
         return ftp_dashboards, missing_paths
 
     def compare_ftp_dashboards(self):
         """Compares dashboards between the cloud and the FTP server using CR name."""
         cloud_dashboards = self.get_cloud_dashboards(use_cr_name=True)
         ftp_dashboards, missing_paths = self.get_ftp_dashboards()
-        
+
         missing_on_ftp = {}
         for path, files in ftp_dashboards.items():
             missing_files = [dashboard for dashboard in cloud_dashboards if f"{dashboard}.json" not in files]
             if missing_files:
                 missing_on_ftp[path] = missing_files
-        
+
         if missing_on_ftp:
-            error_messages = [f"Missing dashboards in {path}: {', '.join(missing)}" for path, missing in missing_on_ftp.items()]
+            error_messages = [
+                f"Missing dashboards in {path}: {', '.join(missing)}" for path, missing in missing_on_ftp.items()
+            ]
             self.built_in.fail("\n".join(error_messages))
-        
+
         if missing_paths:
             self.built_in.fail(f"Missing or empty FTP directories: {', '.join(missing_paths)}")
-        
+
         self.built_in.log("All cloud dashboards are present on FTP.", level="INFO")
         return "All dashboards are available on FTP."
 
@@ -298,29 +308,29 @@ class ConfigurationsStreamerLib:
         ssh_client = self._create_ssh_connection(self.ip_ftp_server)
         missing_or_empty_files = []
         missing_paths = []
-        
+
         try:
             for path in self.ALERTMANAGER_PATHS:
                 file_path = f"{path}/{self.REQUIRED_ALERTMANAGER_FILE}"
                 command = f"test -s {file_path} || echo {file_path}"
                 status, output = self._execute_command_on_vm(ssh_client, command)
-                
+
                 if output.strip():
                     missing_or_empty_files.append(output.strip())
-                
+
                 command = f"ls {path} 2>/dev/null"
                 status, output = self._execute_command_on_vm(ssh_client, command)
                 if status != 0 or not output.strip():
                     missing_paths.append(path)
         finally:
             ssh_client.close()
-        
+
         if missing_paths:
             self.built_in.fail(f"Missing or empty Alertmanager directories: {', '.join(missing_paths)}")
-        
+
         if missing_or_empty_files:
             self.built_in.fail(f"Missing or empty Alertmanager files: {', '.join(missing_or_empty_files)}")
-        
+
         self.built_in.log("All required Alertmanager files are present and non-empty.", level="INFO")
         return "All Alertmanager files verified successfully."
 
@@ -384,11 +394,14 @@ class ConfigurationsStreamerLib:
             self.ip_grafana_creds: set(cloud_rules.keys()) - set(rules_server1.keys()),
             self.ip_grafana_token: set(cloud_rules.keys()) - set(rules_server2.keys())
         }
-        
+
         errors = [f"Missing on {server}: {', '.join(missing)}" for server, missing in missing_rules.items() if missing]
-        
+
         if errors:
             self.built_in.fail("\n".join(errors))
-        
-        self.built_in.log("All PrometheusRules from monitoring and cert-manager namespaces are present on both servers.", level="INFO")
+
+        self.built_in.log(
+            "All PrometheusRules from monitoring and cert-manager namespaces are present on both servers.",
+            level="INFO"
+        )
         return "All PrometheusRules verified successfully."

--- a/test/robot-tests/src/monitoring_pods_checker.py
+++ b/test/robot-tests/src/monitoring_pods_checker.py
@@ -28,6 +28,7 @@ def check_statefulsets_are_ready(service, label):
     else:
         return 0
 
+
 def check_vmagent_targets():
     try:
         pods = k8s_lib.get_pod_names_by_selector(namespace, selector={'app.kubernetes.io/name': 'vmagent'})
@@ -38,7 +39,8 @@ def check_vmagent_targets():
         return 0
     pod_name = pods[0]
     try:
-        last_log = k8s_lib.get_pod_logs(pod_name=pod_name, namespace=namespace, container_name='vmagent', tail_lines=200)
+        last_log = k8s_lib.get_pod_logs(pod_name=pod_name, namespace=namespace,
+                                        container_name='vmagent', tail_lines=200)
     except Exception as e:
         print(f'Failed to get {pod_name} pod logs: {e}')
         return 0
@@ -54,7 +56,7 @@ if __name__ == '__main__':
     except Exception as e:
         print(e)
         exit(1)
-    print('Checking deployments/statefulsets are ready')
+    print('Checking deployments/StatefulSets are ready')
     enabled_services = dict()
     if operator == 'prometheus-operator':
         print('Checking prometheus-operator')
@@ -67,14 +69,14 @@ if __name__ == '__main__':
         print('Checking vmagent-k8s')
         enabled_services['vmagent'] = dict(ready=0, label='app.kubernetes.io/name', kind='deployment')
     else:
-        print(f'Prometheus or victoriametrics operator is not found!')
+        print('Prometheus or victoriametrics operator is not found!')
         exit(1)
     if grafana_operator == 'true':
         print('Checking grafana')
         enabled_services['grafana'] = dict(ready=0, label='app', kind='deployment')
 
     timeout_start = time.time()
-    
+
     all_ready = False
     while time.time() < timeout_start + timeout:
         try:

--- a/test/robot-tests/src/tests/smoke-test/keywords.robot
+++ b/test/robot-tests/src/tests/smoke-test/keywords.robot
@@ -251,12 +251,31 @@ Check Target And Metrics Are Ready
     Check Target Is UP  ${target}  ${all_active_targets}
     Check Job Metrics Are Written  ${target}  ${metrics}
 
+Check Target And Metrics Are Ready Refreshing
+    [Arguments]  ${target}  ${targets_session}  ${metrics_session}
+    ${all_active_targets}=  Get All Active Targets  ${targets_session}
+    ${metrics}=             Get All Metrics From Api  ${metrics_session}
+    ${json_target}=  Get Prometheus Target  ${all_active_targets}  ${target}
+    Run Keyword If  ${json_target}==${False}
+    ...  Fail  Target ${target} missing from ${targets_session} active targets
+    ${is_up}=  Target State And Not Empty  ${json_target}  up
+    Run Keyword If  not ${is_up}
+    ...  Log  Target ${target} not UP yet (session=${targets_session}): ${json_target}  level=WARN
+    Should Be Equal As Strings  ${is_up}  True
+    ${job_metrics}=  Get Metrics By Job  ${metrics}  ${target}
+    Run Keyword If  ${job_metrics}==${False}
+    ...  Log  Job ${target} metrics not present in ${metrics_session} yet (up query result has no matching job)  level=WARN
+    Run Keyword If  ${job_metrics}==${False}
+    ...  Fail  Error! In ${metrics_session} metrics of ${target} don't exist
+    ${status}=  Check Metrics Is Not Empty  ${job_metrics}
+    Should Be Equal As Strings  ${status}  True
+
 Check Vmagent Target Metrics With Retry
     [Arguments]  ${target}  ${all_active_targets}  ${metrics}
     ${flag}=  Wait Until Keyword Succeeds
     ...  ${RETRY_TIME}  ${RETRY_INTERVAL}
-    ...  Check Target And Metrics Are Ready
-    ...  ${target}  ${all_active_targets}  ${metrics}
+    ...  Check Target And Metrics Are Ready Refreshing
+    ...  ${target}  vmagentsession  vmsinglessession
     RETURN  ${flag}
 
 Check Kube State Metrics Are Ready


### PR DESCRIPTION
# What does this PR do?

Smoke tests related to checking the targets and metrics list sometimes failed during the run of integration tests.

The root cause - tests request list of active targets only once and can't update during run.

## Solution

Add logic to update active targets in integration tests.

## Related PRs

- https://github.com/Netcracker/qubership-monitoring-operator/pull/355
- https://github.com/Netcracker/qubership-monitoring-operator/pull/353
- https://github.com/Netcracker/qubership-monitoring-operator/pull/352
- https://github.com/Netcracker/qubership-monitoring-operator/pull/348
- https://github.com/Netcracker/qubership-monitoring-operator/pull/341