### PR TITLE
fix: implement retry logic for GrafanaDashboard resource updates in grafana-operator

### DIFF
--- a/controllers/grafana-operator/handlers.go
+++ b/controllers/grafana-operator/handlers.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
 )
 
 func (r *GrafanaOperatorReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring) error {
@@ -233,31 +234,27 @@ func (r *GrafanaOperatorReconciler) handleGrafanaDashboard(fileName string, cr *
 		r.Log.Error(err, "Failed creating GrafanaDashboard manifest")
 		return err
 	}
-	// Check if resource exists first
-	// Explicitly set GVK to ensure correct API group (grafana.integreatly.org/v1beta1) is used
-	// This is required for Grafana Operator v5 migration from integreatly.org/v1alpha1
-	checkObj := &grafv1.GrafanaDashboard{}
-	checkObj.SetName(m.GetName())
-	checkObj.SetNamespace(m.GetNamespace())
-	checkObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "grafana.integreatly.org", Version: "v1beta1", Kind: "GrafanaDashboard"})
-	if err = r.GetResource(checkObj); err != nil {
-		if errors.IsNotFound(err) {
-			if err = r.CreateResource(cr, m); err != nil {
-				return err
+	// Retry on conflict: the grafana-operator (and other actors) write status/finalizers
+	// on GrafanaDashboard objects concurrently, so a Get-mutate-Update window can race.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Explicitly set GVK to ensure correct API group (grafana.integreatly.org/v1beta1) is used.
+		// Required for Grafana Operator v5 migration from integreatly.org/v1alpha1.
+		checkObj := &grafv1.GrafanaDashboard{}
+		checkObj.SetName(m.GetName())
+		checkObj.SetNamespace(m.GetNamespace())
+		checkObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "grafana.integreatly.org", Version: "v1beta1", Kind: "GrafanaDashboard"})
+		if err := r.GetResource(checkObj); err != nil {
+			if errors.IsNotFound(err) {
+				return r.CreateResource(cr, m)
 			}
-			return nil
+			return err
 		}
-		return err
-	}
 
-	// Set parameters
-	checkObj.SetLabels(m.GetLabels())
-	checkObj.Spec = m.Spec
+		checkObj.SetLabels(m.GetLabels())
+		checkObj.Spec = m.Spec
 
-	if err = r.UpdateResource(checkObj); err != nil {
-		return err
-	}
-	return nil
+		return r.UpdateResource(checkObj)
+	})
 }
 
 func (r *GrafanaOperatorReconciler) handlePodMonitor(cr *monv1.PlatformMonitoring) error {

--- a/controllers/grafana-operator/reconciler.go
+++ b/controllers/grafana-operator/reconciler.go
@@ -4,6 +4,7 @@ import (
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	kubernetes_monitors "github.com/Netcracker/qubership-monitoring-operator/controllers/kubernetes-monitors"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,6 +32,7 @@ func NewGrafanaOperatorReconciler(c client.Client, s *runtime.Scheme, dc discove
 func (r *GrafanaOperatorReconciler) Run(cr *monv1.PlatformMonitoring) error {
 	r.Log.Info("Reconciling component")
 
+	var dashboardErrs []error
 	restrictedDashboards := make(map[string]bool)
 	if cr.Spec.PublicCloudName != "" {
 		if pcMap, ok := utils.PublicCloudDashboardsEnabled[cr.Spec.PublicCloudName]; ok {
@@ -206,7 +208,8 @@ func (r *GrafanaOperatorReconciler) Run(cr *monv1.PlatformMonitoring) error {
 				}
 
 				if err = r.handleGrafanaDashboard(mResource, cr); err != nil {
-					return err
+					r.Log.Error(err, "Can not reconcile GrafanaDashboard", "name", mResource)
+					dashboardErrs = append(dashboardErrs, err)
 				}
 			} else {
 				if err = r.deleteGrafanaDashboard(mResource, cr); err != nil {
@@ -266,6 +269,9 @@ func (r *GrafanaOperatorReconciler) Run(cr *monv1.PlatformMonitoring) error {
 		r.Log.Info("Uninstalling component if exists")
 		r.uninstall(cr)
 		r.Log.Info("Component reconciled")
+	}
+	if len(dashboardErrs) > 0 {
+		return utilerrors.NewAggregate(dashboardErrs)
 	}
 	return nil
 }


### PR DESCRIPTION
# What does this PR do?

I found that conflicts in resources produce errors, such as:

```json
{"level":"ERROR","time":"2026-05-15T09:02:43.324","logger":"controller-platformmonitoring","message":"Reconciliation of grafana-operator failed","error":"Operation cannot be fulfilled on grafanadashboards.grafana.integreatly.org \"kubernetes-top-resources\": the object has been modified; please apply your changes to the latest version and try again"}
```

that triggers an incorrect reconciliation status.

## Solution

Changes:

* Added a retry mechanism to handle conflicts during GrafanaDashboard updates.
* Enhanced error handling in the Run method to aggregate errors related to GrafanaDashboard reconciliation.