### PR TITLE
chore: update datasource references in Helm templates and renovate configuration

### DIFF
--- a/charts/qubership-monitoring-operator/templates/_images.tpl
+++ b/charts/qubership-monitoring-operator/templates/_images.tpl
@@ -29,7 +29,7 @@ Image can be found from:
     {{- if .Values.grafana.operator.image -}}
       {{- printf "%s" .Values.grafana.operator.image -}}
     {{- else -}}
-      {{- /* # renovate: datasource=github-releases depName=grafana-operator/grafana-operator */ -}}
+      {{- /* # renovate: datasource=docker depName=grafana-operator/grafana-operator */ -}}
       {{- print "quay.io/grafana-operator/grafana-operator:v5.22.2" -}}
     {{- end -}}
   {{- end -}}
@@ -45,7 +45,7 @@ Image can be found from:
   {{- if .Values.grafana.image -}}
     {{- printf "%s" .Values.grafana.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=grafana/grafana */ -}}
+    {{- /* # renovate: datasource=docker depName=grafana/grafana */ -}}
     {{- print "docker.io/grafana/grafana:12.4.3" -}}
   {{- end -}}
 {{- end -}}
@@ -61,7 +61,7 @@ Image can be found from:
     {{- if .Values.grafana.operator.initContainerImage -}}
       {{- printf "%s" .Values.grafana.operator.initContainerImage -}}
     {{- else -}}
-      {{- /* # renovate: datasource=github-releases depName=Netcracker/qubership-grafana-plugins-init versioning=semver */ -}}
+      {{- /* # renovate: datasource=docker depName=Netcracker/qubership-grafana-plugins-init versioning=semver */ -}}
       {{- print "ghcr.io/netcracker/qubership-grafana-plugins-init:0.20.0" -}}
     {{- end -}}
   {{- end -}}
@@ -79,7 +79,7 @@ Image can be found from:
   {{- if .Values.prometheus.operator.image -}}
     {{- printf "%s" .Values.prometheus.operator.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator */ -}}
+    {{- /* # renovate: datasource=docker depName=prometheus-operator/prometheus-operator */ -}}
     {{- print "quay.io/prometheus-operator/prometheus-operator:v0.91.0" -}}
   {{- end -}}
 {{- end -}}
@@ -94,7 +94,7 @@ Image can be found from:
   {{- if .Values.prometheus.configReloaderImage -}}
     {{- printf "%s" .Values.prometheus.configReloaderImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator */ -}}
+    {{- /* # renovate: datasource=docker depName=prometheus-operator/prometheus-config-reloader */ -}}
     {{- print "quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0" -}}
   {{- end -}}
 {{- end -}}
@@ -109,7 +109,7 @@ Image can be found from:
   {{- if .Values.alertManager.image -}}
     {{- printf "%s" .Values.alertManager.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus/alertmanager */ -}}
+    {{- /* # renovate: datasource=docker depName=prom/alertmanager */ -}}
     {{- print "docker.io/prom/alertmanager:v0.32.1" -}}
   {{- end -}}
 {{- end -}}
@@ -124,7 +124,7 @@ Image can be found from:
   {{- if .Values.prometheus.image -}}
     {{- printf "%s" .Values.prometheus.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus/prometheus */ -}}
+    {{- /* # renovate: datasource=docker depName=prom/prometheus */ -}}
     {{- print "docker.io/prom/prometheus:v3.11.3" -}}
   {{- end -}}
 {{- end -}}
@@ -141,7 +141,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmOperator.image -}}
     {{- printf "%s" .Values.victoriametrics.vmOperator.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/operator */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
     {{- print "docker.io/victoriametrics/operator:v0.68.4" -}}
   {{- end -}}
 {{- end -}}
@@ -156,7 +156,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmOperator.configReloaderImage -}}
     {{- printf "%s" .Values.victoriametrics.vmOperator.configReloaderImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/operator */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.68.4" -}}
   {{- end -}}
 {{- end -}}
@@ -171,7 +171,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAgent.image -}}
     {{- printf "%s" .Values.victoriametrics.vmAgent.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaMetrics */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/vmagent */ -}}
     {{- print "docker.io/victoriametrics/vmagent:v1.143.0" -}}
   {{- end -}}
 {{- end -}}
@@ -186,7 +186,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAgent.configReloadImage -}}
     {{- printf "%s" .Values.victoriametrics.vmAgent.configReloadImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.68.4" -}}
   {{- end -}}
 {{- end -}}
@@ -201,7 +201,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAlert.image -}}
     {{- printf "%s" .Values.victoriametrics.vmAlert.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaMetrics */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/vmalert */ -}}
     {{- print "docker.io/victoriametrics/vmalert:v1.143.0" -}}
   {{- end -}}
 {{- end -}}
@@ -216,7 +216,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAlert.configReloadImage -}}
     {{- printf "%s" .Values.victoriametrics.vmAlert.configReloadImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=jimmidyson/configmap-reload versioning=semver */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.68.4" -}}
   {{- end -}}
 {{- end -}}
@@ -231,7 +231,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAlertManager.image -}}
     {{- printf "%s" .Values.victoriametrics.vmAlertManager.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus/alertmanager */ -}}
+    {{- /* # renovate: datasource=docker depName=prom/alertmanager */ -}}
     {{- print "docker.io/prom/alertmanager:v0.32.1" -}}
   {{- end -}}
 {{- end -}}
@@ -246,7 +246,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAlertManager.configReloadImage -}}
     {{- printf "%s" .Values.victoriametrics.vmAlertManager.configReloadImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=jimmidyson/configmap-reload versioning=semver */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.68.4" -}}
   {{- end -}}
 {{- end -}}
@@ -261,7 +261,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAuth.image -}}
     {{- printf "%s" .Values.victoriametrics.vmAuth.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaMetrics */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/vmauth */ -}}
     {{- print "docker.io/victoriametrics/vmauth:v1.143.0" -}}
   {{- end -}}
 {{- end -}}
@@ -276,7 +276,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmCluster.vmSelectImage -}}
     {{- printf "%s" .Values.victoriametrics.vmCluster.vmSelectImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaMetrics */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/vmselect */ -}}
     {{- print "docker.io/victoriametrics/vmselect:v1.143.0-cluster" -}}
   {{- end -}}
 {{- end -}}
@@ -291,7 +291,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmCluster.vmStorageImage -}}
     {{- printf "%s" .Values.victoriametrics.vmCluster.vmStorageImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaMetrics */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/vmstorage */ -}}
     {{- print "docker.io/victoriametrics/vmstorage:v1.143.0-cluster" -}}
   {{- end -}}
 {{- end -}}
@@ -306,7 +306,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmCluster.vmInsertImage -}}
     {{- printf "%s" .Values.victoriametrics.vmCluster.vmInsertImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaMetrics */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/vminsert */ -}}
     {{- print "docker.io/victoriametrics/vminsert:v1.143.0-cluster" -}}
   {{- end -}}
 {{- end -}}
@@ -321,7 +321,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAuth.configReloadImage -}}
     {{- printf "%s" .Values.victoriametrics.vmAuth.configReloadImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.68.4" -}}
   {{- end -}}
 {{- end -}}
@@ -336,7 +336,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmSingle.image -}}
     {{- printf "%s" .Values.victoriametrics.vmSingle.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/VictoriaMetrics */ -}}
+    {{- /* # renovate: datasource=docker depName=victoriametrics/victoria-metrics */ -}}
     {{- print  "docker.io/victoriametrics/victoria-metrics:v1.143.0" -}}
   {{- end -}}
 {{- end -}}
@@ -368,7 +368,7 @@ Image can be found from:
   {{- if .Values.nodeExporter.image -}}
     {{- printf "%s" .Values.nodeExporter.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus/node_exporter */ -}}
+    {{- /* # renovate: datasource=docker depName=prom/node-exporter */ -}}
     {{- print "docker.io/prom/node-exporter:v1.11.1" -}}
   {{- end -}}
 {{- end -}}
@@ -383,7 +383,7 @@ Image can be found from:
   {{- if .Values.pushgateway.image -}}
     {{- printf "%s" .Values.pushgateway.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=github-releases depName=prometheus/pushgateway */ -}}
+    {{- /* # renovate: datasource=docker depName=prom/pushgateway */ -}}
     {{- print "docker.io/prom/pushgateway:v1.11.2" -}}
   {{- end -}}
 {{- end -}}

--- a/renovate.json
+++ b/renovate.json
@@ -28,9 +28,9 @@
         "/.github/workflows/integration-tests\\.yaml/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[a-z-0-9]+))?[^\\n]*\\n[^\\n]*?(?<currentValue>[0-9][^\\s\"'\\n<]*)"
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+)(?: versioning=(?<versioning>[a-z-0-9]+))?[^\\n]*\\n[^\\n]*:(?<currentValue>[^\\s\"'\\n]+)"
       ],
-      "extractVersionTemplate": "(?<version>[0-9][^:]*$)"
+      "extractVersionTemplate": "^(?:config-reloader-)?v?(?<version>\\d+(?:\\.\\d+)*)"
     },
     {
       "customType": "regex",
@@ -87,6 +87,18 @@
       ],
       "groupName": "netcracker-workflows",
       "separateMajorMinor": false
+    },
+    {
+      "description": "VictoriaMetrics cluster images use -cluster docker tag suffix (vmselect, vmstorage, vminsert)",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "victoriametrics/vmselect",
+        "victoriametrics/vmstorage",
+        "victoriametrics/vminsert"
+      ],
+      "versionCompatibility": "^(?<version>v\\d+\\.\\d+\\.\\d+)(?<compatibility>-cluster)$",
+      "versioning": "docker"
     },
     {
       "description": "Group Netcracker docker images (overrides third-party-images group)",


### PR DESCRIPTION
# What does this PR do?

- Changed datasource from GitHub releases to Docker for various images in _images.tpl.
- Updated match strings and version extraction templates in renovate.json for better compatibility with Docker images.
- Added support for VictoriaMetrics cluster images in renovate configuration.