### PR TITLE
chore: update release drafter configuration to enhance labeling and categorization

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -18,7 +18,11 @@ categories:
     labels:
       - refactor
   - title: "🧰 Maintenance"
-    label: chore
+    labels:
+      - chore
+  - title: "🔍 Other Changes"
+    labels:
+      - "*"
   - title: "⬆️ Dependencies"
     collapse-after: 8
     labels:
@@ -67,7 +71,7 @@ autolabeler:
     files:
       - '*.md'
       - 'docs/**'
-  - label: 'bug'
+  - label: 'fix'
     branch:
       - '/fix\/.+/'
     title:


### PR DESCRIPTION
# What does this PR do?

- Changed the label for the maintenance category from 'chore' to a list format.
- Added a new category for "Other Changes" with a wildcard label.
- Updated the label for bug-related changes from 'bug' to 'fix' for consistency.