### PR TITLE
chore: replace deprecated schema.Builder

### DIFF
--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -6,17 +6,26 @@
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
-	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "monitoring.netcracker.com", Version: "v1"}
+	// GroupVersion is group version used to register these objects
+	GroupVersion = schema.GroupVersion{Group: "monitoring.netcracker.com", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	AddToScheme = schemeBuilder.AddToScheme
+
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/v1/platformmonitoring_types.go
+++ b/api/v1/platformmonitoring_types.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/api/v1/platformmonitoring_types.go
+++ b/api/v1/platformmonitoring_types.go
@@ -1790,7 +1790,7 @@ type Promxy struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&PlatformMonitoring{}, &PlatformMonitoringList{})
+	objectTypes = append(objectTypes, &PlatformMonitoring{}, &PlatformMonitoringList{})
 }
 
 // IsInstall check if AlertManager should be installed


### PR DESCRIPTION
# What does this PR do?

During work on PR https://github.com/Netcracker/qubership-monitoring-operator/pull/367, I saw the issue highlighted by golangci-linter:

```bash
../../api/v1/groupversion_info.go:18:19: SA1019: scheme.Builder is deprecated: This helper is only useful in api packages, but api packages should be easy to import and hence have minimal dependencies. Typically, these dependencies include only the standard library, k8s.io/apimachinery and other api packages. (staticcheck)
	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
	                 ^
1 issues:
* staticcheck: 1
```

To don't mix changes, I decided to make a separate PR to replace deprecated `&schema.Builder`.
Code changed based on the recommendation from the Kubernetes Cluster API book:
https://cluster-api.sigs.k8s.io/developer/providers/getting-started/implement-api-types#registering-apis-in-the-scheme