### PR TITLE
chore(go): add toolchain directive to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/Netcracker/qubership-monitoring-operator
 
 go 1.26.0
+toolchain go1.26.4
 
 require (
 	github.com/VictoriaMetrics/operator/api v0.66.1


### PR DESCRIPTION
Adds an explicit toolchain directive to go.mod that matches the existing go version (go1.26.0). See Go toolchain management docs: https://go.dev/doc/toolchain

Supersedes #395.