### PR TITLE
fix: add pages environment to docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,6 +35,9 @@ jobs:
       contents: read
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     # Only deploy from main branch, not from PRs
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
## Summary
- Add the `github-pages` environment to the docs deployment job.
- Publish the deployed Pages URL as the environment URL.

## Context
The docs deployment last succeeded on May 25, 2026 and failed on July 3, 2026.
Build and artifact upload passed; only `actions/deploy-pages` failed with `deployment_failed`.

`actions/deploy-pages` recommends targeting the `github-pages` environment, so this PR adds it explicitly.

## Verification
- `actionlint .github/workflows/deploy-docs.yml`