### PR TITLE
fix: Update pipeline version to v1.14.1

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -63,9 +63,9 @@ jobs:
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           github.event.pull_request.user.login != 'renovate[bot]'
         )
-    uses: Netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@9fcb2de51b4d510b52ffca883515bdb388cbc16f # v1.14.0
+    uses: Netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@ddc741b38bac5dc4834b8f6827c9f6d16abf0db8 # v1.14.1
     with:
       service_branch: ${{ github.sha }}
-      pipeline_branch: 'c46738acd2481dcea8b4cd0bee83e3f4f4539f2c' # this value must match the value after '@' in 'uses'
+      pipeline_branch: 'ddc741b38bac5dc4834b8f6827c9f6d16abf0db8' # v1.14.1 renovate: depName=Netcracker/qubership-test-pipelines
       repository_name: '${{ github.repository_owner }}/qubership-monitoring-operator'
       kind-layout: 'single-node'

--- a/.github/workflows/test-nightly-integration.yaml
+++ b/.github/workflows/test-nightly-integration.yaml
@@ -9,14 +9,13 @@ on:
 
 jobs:
   Nightly-Monitoring-Pipeline:
-    uses: Netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@9fcb2de51b4d510b52ffca883515bdb388cbc16f # v1.14.0
+    uses: Netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@ddc741b38bac5dc4834b8f6827c9f6d16abf0db8 # v1.14.1
     with:
       service_branch: main
-      pipeline_branch: 'c46738acd2481dcea8b4cd0bee83e3f4f4539f2c' # this value must match the value after '@' in 'uses'
+      pipeline_branch: 'ddc741b38bac5dc4834b8f6827c9f6d16abf0db8' # v1.14.1 renovate: depName=Netcracker/qubership-test-pipelines
       repository_name: '${{ github.repository_owner }}/qubership-monitoring-operator'
       kind-layout: 'single-node'
       scope: 'nightly'
     secrets:
       AWS_S3_ACCESS_KEY_ID: ${{secrets.AWS_S3_ACCESS_KEY_ID}}
       AWS_S3_ACCESS_KEY_SECRET: ${{secrets.AWS_S3_ACCESS_KEY_SECRET}}
-

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "schedule:weekly"
+    "schedule:weekly",
+    "github>Netcracker/renovate-config:test-pipelines"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
## Why

Test pipeline v1.14.1 fixes the required-secrets validation issue tracked in [qubership-test-pipelines#271](https://github.com/Netcracker/qubership-test-pipelines/issues/271), which caused the [integration test workflow](https://github.com/Netcracker/qubership-monitoring-operator/actions/runs/29088937298) to be rejected.

The workflow pins both a test-pipeline tag and its commit SHA. These values must be updated together by Renovate.

## What changed

- Updated the test-pipeline references to v1.14.1 in both workflows.
- Enabled the shared `test-pipelines` Renovate preset so future tag updates also refresh `pipeline_branch`.

## Dependency and merge order

Depends on [Netcracker/renovate-config#24](https://github.com/Netcracker/renovate-config/pull/24). Merge that PR first so the `test-pipelines` preset is available from the default branch before this repository starts extending it.

## Verification

- `actionlint`
- Strict Renovate configuration validation
- Existing PR CI
