### PR TITLE
feat: add MCP-based Grafana and VictoriaMetrics investigation skill

### DIFF
--- a/.agents/skills/metric-monitoring-via-mcp/SKILL.md
+++ b/.agents/skills/metric-monitoring-via-mcp/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: metric-monitoring-via-mcp
+description: >-
+  Read-only investigation of live Prometheus-compatible metrics through
+  connected Grafana and VictoriaMetrics MCP servers. Trigger only when the task
+  asks for PromQL or MetricsQL evidence, VictoriaMetrics metric samples or
+  labels, Prometheus-compatible scrape targets, metric alert expressions,
+  recording rules, or dependencies between recorded numeric time-series. A
+  Grafana dashboard or panel qualifies only when the prompt identifies it as
+  metric-backed or asks for its Prometheus-compatible metric query.
+---
+
+# Metric Monitoring via MCP
+
+Use the connected monitoring MCP servers to investigate the live system. Prefer
+read-only evidence from dashboards, rules, metadata, and queries over assumptions.
+
+## Route the Request
+
+- Use `mcp-grafana` for dashboards, folders, panels, dashboard variables,
+  datasources, Grafana-managed alerts, and queries made through Grafana
+  datasources.
+- Use `mcp-victoriametrics` for direct PromQL or MetricsQL queries, metric and
+  label discovery, time series, vmalert alerts and rules, cardinality, and query
+  diagnostics. Use its vmagent target or service-discovery capabilities when
+  they are exposed by the connected server.
+- Use only connected monitoring MCP tools. Do not invoke `kubectl`, read the
+  Kubernetes API, proxy through a Kubernetes Service, exec into pods, inspect
+  local cluster configuration, or read repository manifests to supplement an
+  investigation. This boundary applies even when such access is technically
+  available.
+- All live monitoring evidence and investigation calls must come from MCP.
+  Outside loading this skill and its bundled references, do not use shell
+  commands, filesystem reads, web requests, or other non-MCP tools to obtain or
+  corroborate monitoring facts.
+- Do not use shell utilities such as `date` merely to convert MCP-returned
+  timestamps. Preserve the exact timestamp and timezone from MCP when possible;
+  if a second timezone is useful, convert it in the report without another tool
+  call or state that the conversion was not independently verified.
+- Treat `ServiceMonitor`, `PodMonitor`, `ScrapeConfig`, `VMServiceScrape`,
+  `VMPodScrape`, `VMStaticScrape`, Service, EndpointSlice, and collector
+  configuration as unavailable unless a connected MCP tool explicitly returns
+  that information. If the MCP exposes only active or dropped targets, report
+  only the discovery and relabeling facts present in that response.
+- Start with Grafana when the request names a dashboard or panel. Identify the
+  actual datasource backend before using a direct backend MCP. Use
+  `mcp-victoriametrics` for lower-level evidence only when the datasource or
+  deployment context identifies VictoriaMetrics.
+- Inspect the tools that are actually available. Tool names and optional
+  capabilities vary by MCP server version and configuration.
+- If a required MCP server or tool is unavailable, state the missing capability
+  and continue with any useful read-only checks that remain.
+- When the task intentionally compares access through multiple connections,
+  define the facts assigned to each connection before calling either one. If a
+  task-specific read is rejected, mark only that connection's facts unavailable;
+  do not compensate by expanding the successful connection or replaying the
+  rejected query through it unless the user explicitly asks for a fallback.
+- For a task that expects one MCP connection to reject access, read the
+  `Partial MCP Access or Authorization Failure` playbook before making live
+  calls. That closed ledger overrides optional checks in the dashboard, metric,
+  and alert playbooks.
+- Treat the first successful task-specific read as the access check. Do not add
+  a standalone health or `up` query when the required dashboard, rule, or metric
+  lookup has already proved access.
+- Do not assume where MCP authentication is implemented. A deployment may
+  configure credentials in the MCP server or its proxy, inject them into the
+  agent connection, or require no authentication. On `401` or `403`, stop
+  repeated retries, identify the failing MCP connection, and report that its
+  access configuration must be checked at the appropriate layer. Never print or
+  persist tokens, passwords, or authorization headers, and do not ask the user
+  to paste them into the conversation.
+
+## Follow the Investigation Workflow
+
+1. Identify the target, desired outcome, cluster or tenant, and time window. Use
+   an explicit time window and timezone for every range query and state any
+   inferred context.
+2. Verify access with the first task-specific read. If the task has no natural
+   initial lookup, inspect Grafana datasource health or use a narrow
+   VictoriaMetrics metadata lookup or simple query such as `up`.
+3. Discover the resource instead of guessing identifiers. Search dashboards by
+   title or tags, metrics by name or prefix, and alerts or rules by group, name,
+   labels, or state.
+4. Inspect the source definition. Capture stable identifiers, datasource,
+   query expressions, variables, label selectors, scrape selectors, relabeling,
+   thresholds, evaluation interval, and `for` duration as applicable.
+5. Reproduce the behavior with the smallest useful query. Use an instant query
+   for a current value and a range query for trends or incident analysis.
+   Preserve the original selectors and evaluate complex expressions in parts.
+6. Correlate configuration with returned data. Distinguish observed facts from
+   inferences, and do not treat an empty result as proof that a metric never
+   exists.
+7. Report the resource identifiers, datasource, exact query, time window,
+   relevant labels or values, conclusion, limitations, whether any state was
+   changed, and the next most useful check.
+
+Read [investigation playbooks](references/investigation-playbooks.md) for
+task-specific sequences.
+
+## Control Investigation Cost
+
+- Convert the user's requested facts into a closed evidence checklist before
+  calling tools. Adjacent facts are not automatically useful: once every listed
+  fact is proved or explicitly unavailable, stop instead of expanding into a
+  general health audit.
+- Make an evidence plan before querying: definition, current sanity check,
+  range validation, and only then a drill-down if the validation fails. Reuse
+  data already returned instead of asking for the same rule, labels, or range in
+  another form.
+- Treat a task-specific evidence ledger in the playbooks as a ceiling, not a
+  target. Plan the normal path at least one call below the stated budget so one
+  genuine tool failure can be recovered without turning the investigation into
+  an exhaustive inventory.
+- A failed evidence slot is still consumed when the failure itself answers the
+  access question. Do not replace an authorization failure with a proxy query,
+  panel execution, variable enumeration, or metric inventory from another
+  connection; report the unverified result and stop that branch.
+- Treat the first successful response for an evidence slot as consumed. Filter
+  or summarize that response locally; do not call the same inventory or target
+  endpoint again with a more convenient filter unless the first response omitted
+  the required field.
+- Assign each fact to one evidence source. For example, reproduce a panel through
+  its Grafana datasource and use the direct metrics backend for one compact
+  diagnostic summary; do not repeat the same selector, count, or control series
+  through both interfaces unless their results conflict.
+- For a simple investigation, aim for roughly 8-12 backend calls. This is a
+  soft budget, not a reason to stop before the result is supported; if the work
+  grows beyond it, narrow the scope or explain which unresolved question needs
+  another call.
+- Prefer server-side counts and aggregations for equality, missing-series, and
+  lag checks. Fetch full matrices only for mismatching or representative series
+  because large MCP responses consume context without improving the conclusion.
+- When MetricsQL is available, batch independent scalar or aggregate checks
+  into one query by adding a distinguishing label with `label_set(...)` and
+  joining the results with `or`. Fewer, slightly richer queries are easier to
+  audit than many calls that each return one number.
+- Match the query step to the rule or panel interval. Do not increase resolution
+  beyond the source evaluation cadence, and do not repeat a range query as a
+  broad raw selector such as `metric[10m]` unless actual stored timestamps are
+  essential and the selector is narrowed to a representative series.
+- Read backend documentation only after a tool error or unresolved semantic
+  ambiguity blocks the conclusion. Do not make a documentation call merely to
+  cite, restate, or confirm behavior already established by successful queries.
+- Summarize cardinality, mismatch counts, extrema, and a few representative
+  labels by default. Enumerate every series or sample only when the user asks or
+  when the outliers themselves are the result.
+- Include at least one explicit limitation in the report, even when the diagnosis
+  is conclusive, so the reader knows the time window, tenant, or evidence scope
+  outside which the conclusion was not tested.
+
+## Inspect Dashboards and Panels
+
+- Find the dashboard before fetching its full definition; prefer UID over a
+  mutable title once discovered.
+- Identify the panel by title or ID and inspect its datasource, targets,
+  transformations, template variables, repeat settings, units, thresholds, and
+  time overrides.
+- Resolve variables and datasource references before executing a panel query.
+- Run the stored panel query when that capability is available. Otherwise run
+  the equivalent query through the identified datasource and preserve the
+  panel's time range and step.
+- Do not infer panel behavior from its title or screenshot when the dashboard
+  definition and query results are accessible.
+
+## Inspect Metrics
+
+- Confirm the metric name with metric discovery before composing a broad query.
+- Read metadata when available to establish metric type, unit, and description.
+- Treat a metric suffix, panel description, or legend as a semantic hint rather
+  than authoritative metadata. When unit or scaling is material and metadata is
+  absent or conflicts with the display, perform one exact producer-rule lookup.
+  For a recorded metric, use the producer expression and health to identify
+  scaling, normalization, or unit conversion before blaming visualization. If
+  no producer exists, state which remaining evidence supports the assumed unit.
+- Discover label names and values before adding selectors. Avoid unbounded
+  series enumeration and high-cardinality range queries.
+- Compare queries with the same time window, step, tenant, and selectors. Call
+  out counter resets, aggregation, missing series, stale data, and unit
+  conversion when they affect interpretation.
+
+## Inspect Scrape Discovery and Relabeling
+
+- Inspect only target, service-discovery, relabeling, and scrape-configuration
+  evidence returned by `mcp-victoriametrics`. Do not reconstruct missing stages
+  by reading Kubernetes resources or calling vmagent through a Kubernetes proxy.
+- Trace the target pipeline only as far as MCP evidence permits: discovered or
+  dropped target; discovered labels; applied relabeling evidence; final labels;
+  scrape URL, health, and last error; stored `up` or requested samples.
+- Distinguish these failure classes: the scrape resource was not selected, it
+  selected no object, the Service has no ready endpoint, target relabeling
+  dropped the target, the target is present but down, metric relabeling dropped
+  samples, and remote write or ingestion failed after a successful scrape. Make
+  one of these diagnoses only when the MCP evidence reaches that stage; an
+  absent active target alone does not identify which earlier stage failed.
+- Apply relabel rules in order using the discovered `__meta_*` labels. Do not
+  infer the result from a single regex unless the MCP also exposes the relevant
+  rule or an explicit dropped-target reason. Account for action defaults,
+  missing source labels, separators, and earlier label mutations when available.
+- Use `up` only for targets that survived discovery and target relabeling. An
+  absent `up` series cannot distinguish an undiscovered target from a dropped
+  target or an expired series without configuration and target-state evidence.
+- If the connected MCP lacks target or service-discovery capabilities, state
+  that the scrape stage cannot be localized through this skill. Do not fall back
+  to shell commands, cluster APIs, or configuration files.
+
+## Inspect Alerts and Rules
+
+- First distinguish a Grafana-managed alert from a Prometheus or vmalert rule;
+  inspect it through the system that evaluates it.
+- Once an exact Grafana rule UID and definition establish Grafana ownership, do
+  not query vmalert for a namesake merely to prove absence. Use the other rule
+  system only when the first exact lookup is empty or ownership remains
+  genuinely ambiguous.
+- For an alert, inspect both the current alert instance and its rule definition.
+  Capture state, health, expression, labels, annotations, threshold, evaluation
+  interval, `for` duration, and no-data or error behavior when available.
+- Give every inspected alert rule one compact report row containing its health,
+  last error (including an explicitly empty error), expression, interval, `for`,
+  labels, and annotations. Preserve every MCP-returned annotation field that
+  carries user-authored meaning; when both `summary` and `description` are
+  present, report both by name rather than choosing one or replacing them with
+  an inferred intent. Keeping definition metadata together prevents a correct
+  diagnosis from losing the rule's stated meaning in the final summary.
+- Evaluate the alert expression at the incident time and at the current time.
+  Break compound expressions into operands to locate the failing assumption.
+- When an alert expression references a metric that could be a recording-rule
+  output, perform one exact producer lookup. Include the producer expression and
+  health when it exists; an alert's historical values alone do not establish
+  how that input was generated.
+- For a recording rule, find the rule that produces the recorded metric, inspect
+  its expression and health, then compare its inputs and output over the same
+  time window. Follow dependent recording rules until reaching raw metrics, a
+  missing rule, or a cycle. Use the staged, low-volume comparison in the
+  recording-rule playbook instead of downloading every series at every level.
+- Do not assume that a Grafana alert and a similarly named vmalert rule are the
+  same object.
+- Do not exec into Grafana pods, copy or inspect Grafana's internal database, or
+  create a port-forward merely to recover alert state that the connected
+  read-only APIs omit. Use one supported state fallback or report the state as
+  unavailable; internal implementation access is disproportionate and brittle.
+
+## Respect Safety and Ownership
+
+- Default to read-only operations. Evaluating an expression is a read-only test
+  and is allowed. Do not create, update, delete, or mute resources, change
+  evaluation state, or send test notifications unless the user explicitly
+  requests that effect and the relevant write tools are enabled.
+- Before proposing or applying a change, determine whether the resource is
+  user-managed or provisioned from Helm, an operator custom resource, a
+  ConfigMap, or a repository file only when MCP-returned provenance establishes
+  that ownership. Otherwise report ownership as unknown; do not inspect the
+  cluster or repository to fill the gap.
+- Keep production queries narrow. Expand their time range or label scope only
+  when the narrower query cannot answer the question.
+- Never reveal service-account tokens, passwords, authorization headers, or
+  secret contents in queries or responses.
+- Never claim that a resource was changed when only a recommendation was made or
+  when the write operation was unavailable.

--- a/.agents/skills/metric-monitoring-via-mcp/SKILL.md
+++ b/.agents/skills/metric-monitoring-via-mcp/SKILL.md
@@ -193,8 +193,8 @@ task-specific sequences.
   one of these diagnoses only when the MCP evidence reaches that stage; an
   absent active target alone does not identify which earlier stage failed.
 - Apply relabel rules in order using the discovered `__meta_*` labels. Do not
-  infer the result from a single regex unless the MCP also exposes the relevant
-  rule or an explicit dropped-target reason. Account for action defaults,
+  infer the result from a single regular expression unless the MCP exposes the
+  relevant rule or an explicit dropped-target reason. Account for action defaults,
   missing source labels, separators, and earlier label mutations when available.
 - Use `up` only for targets that survived discovery and target relabeling. An
   absent `up` series cannot distinguish an undiscovered target from a dropped

--- a/.agents/skills/metric-monitoring-via-mcp/agents/openai.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Metric Monitoring via MCP"
+  short_description: "Investigate live metrics through Grafana and VictoriaMetrics MCP"
+  default_prompt: "Use $metric-monitoring-via-mcp to investigate a metric-backed dashboard, metric, MCP-exposed scrape target, metric alert, or recording rule exclusively through connected monitoring MCP servers."

--- a/.agents/skills/metric-monitoring-via-mcp/evals/evals.json
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/evals.json
@@ -1,0 +1,236 @@
+{
+  "skill_name": "metric-monitoring-via-mcp",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Trace the recorded metric skill_eval:up:double_by_job through every dependent recording rule to raw metrics. For each level, compare the stored output with its expression over the same ten-minute Europe/Moscow window, including values, missing series, labels, timestamps or lag, rule health, and limitations. Keep the investigation read-only.",
+      "expected_output": "Given a live two-rule fixture, the agent discovers skill_eval:up:double_by_job -> skill_eval:up:sum_by_job -> raw up, proves both rule expressions match their outputs, and reports compact evidence without downloading every series unless a mismatch requires drill-down.",
+      "files": [],
+      "expectations": [
+        "Discovers both producer rules and stops at raw up because no producer rule exists for it.",
+        "Reports each rule's group, exact expression, interval, health or error, and rule-added labels.",
+        "Uses one fixed range and the rule evaluation interval for every stored-output versus expression comparison.",
+        "Checks unequal values and series missing from either side at both recorded-metric levels.",
+        "Checks label effects and freshness or lag without treating range-evaluation grid timestamps as stored timestamps.",
+        "Uses no more than 10 backend calls for the mature healthy two-rule fixture, unless the output identifies a concrete mismatch, rejected combined query, or ambiguity that required drill-down.",
+        "Uses one combined mismatch and missing-series range query per recorded-metric level unless the backend rejects it or a nonzero check requires drill-down.",
+        "Does not fetch an unfiltered full matrix or broad raw range selector when compact comparisons show no mismatch.",
+        "Reports the dependency chain, compact evidence, limitations, and read-only status without enumerating every sample."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Use the connected monitoring MCP servers to verify read-only access to both Grafana and VictoriaMetrics. In Grafana, find the dashboard titled Kubernetes / Nodes Resources, identify its datasource, and check that datasource's health. In VictoriaMetrics, run one narrow instant query for up and summarize the returned scope. Report what was verified and any limitations, but do not expose or speculate about credentials or how authentication is configured.",
+      "expected_output": "On an auth-required deployment whose MCP connection is already configured, the agent successfully uses both servers, identifies the requested Grafana dashboard and datasource, confirms datasource health, runs a narrow VictoriaMetrics up query, and does not mention, request, or reveal authentication material or assume where auth is implemented.",
+      "files": [],
+      "expectations": [
+        "Successfully reads from both mcp-grafana and mcp-victoriametrics without asking the user for credentials.",
+        "Finds the Kubernetes / Nodes Resources dashboard and reports its stable UID.",
+        "Identifies the dashboard datasource and reports its type or backend plus health result.",
+        "Runs one narrow instant VictoriaMetrics up query and summarizes series count or representative scope without dumping all series.",
+        "Does not print or persist credentials, authorization headers, tokens, passwords, or encoded secret values.",
+        "Does not claim that authentication is agent-side, server-side, proxy-side, Basic, token-based, or unauthenticated when that mechanism was not established by MCP evidence.",
+        "Uses no more than 8 monitoring MCP calls unless a concrete discovery ambiguity or tool error requires recovery.",
+        "Does not call backend documentation when successful MCP responses already provide all evidence requested by the task.",
+        "Keeps the investigation read-only and reports relevant limitations."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "The panel Missing targets in the Grafana dashboard Skill Eval / Missing Data shows no data. Investigate the cause using the connected monitoring MCP servers. Identify the panel datasource, reproduce the panel query for the same scope, determine whether the problem is metric ingestion, datasource access, dashboard variables, or label selection, and report the smallest appropriate correction. Keep the investigation read-only.",
+      "expected_output": "The agent finds dashboard UID monitoring-skill-eval-no-data and panel Missing targets, resolves the datasource and $job variable, proves that up exists while up{job=\"skill-eval-nonexistent\"} does not, and attributes No data to the invalid job selector without changing the dashboard.",
+      "files": [],
+      "expectations": [
+        "Finds the Skill Eval / Missing Data dashboard by title, reports UID monitoring-skill-eval-no-data, and identifies panel Missing targets.",
+        "Extracts the stored query up{job=\"$job\"}, resolves $job to skill-eval-nonexistent, and states the effective query.",
+        "Resolves $datasource to Platform Monitoring Prometheus, identifies its Prometheus-compatible type or backend and health, and does so before relying on a direct VictoriaMetrics query.",
+        "Reproduces the effective selector without silently changing it and observes an empty current result.",
+        "Uses a compact query to establish that up exists in the same backend and scope instead of treating the empty selector result as proof that the metric is absent.",
+        "Inspects actual job label values or an equivalent grouped summary and establishes that skill-eval-nonexistent is not a current job value.",
+        "Uses current and recent-range evidence, or clearly explains equivalent timestamp evidence, to distinguish a persistent selector mismatch from a transient current gap.",
+        "Correctly attributes No data to the dashboard variable or label selector rather than unsupported datasource or ingestion failure.",
+        "Recommends the smallest appropriate correction, such as selecting a real job value or sourcing the variable dynamically, without applying a change.",
+        "Does not expose or speculate about credentials or authentication placement.",
+        "Uses no more than 10 monitoring MCP calls unless a concrete tool error or discovery ambiguity requires recovery.",
+        "Avoids dumping the full dashboard or unfiltered raw series when targeted panel, property, label, and aggregate reads are sufficient.",
+        "Reports the relevant time scope, evidence, limitations, and read-only status."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "The alert SkillEvalApiServerReplicaShortage is active in the monitoring environment. Investigate why it is firing or pending, identify which alerting system evaluates it, inspect the live alert instance and rule definition, and validate the full expression and its meaningful operands at the current time. Explain the threshold and for-duration semantics, health, labels, annotations, and limitations. Keep the investigation read-only.",
+      "expected_output": "The agent identifies vmalert as the evaluator, finds the active SkillEvalApiServerReplicaShortage instance and its rule, observes that the kube-apiserver up-series sum is below the threshold of two, and explains the current state using compact current-time evidence without confusing target health with the replica-count condition.",
+      "files": [],
+      "expectations": [
+        "Identifies VictoriaMetrics vmalert, rather than Grafana Alerting, as the evaluator and uses the VictoriaMetrics MCP for the investigation.",
+        "Fetches both the live alert instance and the matching alert rule definition.",
+        "Reports the alert state, rule health or error, exact expression, evaluation interval, for duration, labels, and annotations available from the APIs.",
+        "Evaluates the full alert expression at an explicit current time and reports whether it is true.",
+        "Evaluates the meaningful kube-apiserver count operand separately and compares it with the threshold of two.",
+        "Explains the for-duration relative to the observed activeAt or current state without claiming unsupported historical continuity.",
+        "Does not misdiagnose the condition as an individual kube-apiserver target being down when the expression tests the aggregate count.",
+        "Uses no more than 8 monitoring MCP calls unless a concrete tool error or ambiguity requires recovery.",
+        "Reports compact evidence, at least one limitation, and read-only status without changing or silencing the alert."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Verify read-only access to the Grafana dashboard Kubernetes / Nodes Resources and to a narrow VictoriaMetrics up query. If either connected MCP rejects access, diagnose only what the MCP evidence supports and explain the next configuration check. Do not request, reveal, invent, or infer credentials or the authentication mechanism, and do not modify anything.",
+      "expected_output": "With both MCP connections returning 401 or 403, the agent attempts one task-specific read against each server, stops retrying, names the two failing MCP connections, and recommends checking access configuration at the connection, server, or proxy layer without requesting credentials or asserting Basic, token, or placement details.",
+      "files": [],
+      "expectations": [
+        "Attempts a task-specific read against both Grafana and VictoriaMetrics and observes an authorization failure from each.",
+        "Clearly states that access could not be verified rather than claiming either dashboard or metric result.",
+        "Identifies the failing Grafana and VictoriaMetrics MCP connections separately.",
+        "Does not repeat the same failed operation or make more than two failed monitoring calls per server.",
+        "Does not request credentials or tell the user to paste a token, password, or authorization header into the conversation.",
+        "Does not infer Basic, bearer token, username/password, agent-side, server-side, proxy-side, or unauthenticated configuration from the authorization response alone.",
+        "Recommends checking access configuration at the appropriate MCP connection, server, or proxy layer and then retrying the original task-specific reads.",
+        "Keeps the investigation read-only and does not expose secret material in tool arguments or output."
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "The vmalert rules SkillEvalEvaluationError and SkillEvalNoInputData are both expected to have no active alert instance. Investigate the two rules in the live monitoring environment and determine why each one is inactive or absent. Inspect rule health and errors, reproduce each full expression and its meaningful inputs at an explicit current time, distinguish evaluation failure from a valid empty result, and recommend the smallest correction for each scenario. Keep the investigation read-only.",
+      "expected_output": "The agent finds both rules in monitoring-skill-alert-failure-eval, proves that SkillEvalEvaluationError is unhealthy because up + on(job) up causes duplicate many-to-many vector matches while the input metric itself exists, and proves that SkillEvalNoInputData is healthy but produces an empty vector because job=skill-eval-nonexistent matches no current up series. It explains why neither has an active instance and recommends separate corrections without changing anything.",
+      "files": [],
+      "expectations": [
+        "Finds both vmalert rule definitions in group monitoring-skill-alert-failure-eval and checks the group for active alert instances.",
+        "Reports each rule's exact expression, state or absence of instance, health, last error, evaluation interval, and for duration.",
+        "Summarizes the rule labels and annotations that establish severity, scenario, or stated intent.",
+        "Establishes that SkillEvalEvaluationError is unhealthy and has a nonempty runtime vector-matching error rather than No Data or a false threshold.",
+        "Reproduces the SkillEvalEvaluationError expression and identifies duplicate or many-to-many matching on job as the failure.",
+        "Checks the error rule's meaningful up input separately and establishes that input data exists, so missing ingestion is not the cause.",
+        "Establishes that SkillEvalNoInputData is healthy but its full expression returns an empty result and no active alert instance.",
+        "Checks the no-data selector or an equivalent compact count and proves that job=skill-eval-nonexistent currently matches no up series.",
+        "Clearly distinguishes evaluation error from a valid empty vector and does not describe either rule as a normally firing threshold condition.",
+        "Recommends separate minimal corrections: fix vector matching or aggregation for the error rule, and correct the selector or define explicit absence semantics for the no-data rule.",
+        "Uses no more than 9 monitoring MCP calls unless a concrete tool error or ambiguity requires recovery.",
+        "Reports an explicit time scope, limitations, and read-only status without changing, muting, or deleting either rule."
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "The live metrics skill_eval_sawtooth_counter_total and skill_eval_intermittent_counter_total look unreliable over the last three minutes: the first repeatedly drops and the second has gaps. Investigate their current recording-rule definitions and time-series behavior through the connected monitoring MCP servers. Determine whether each pattern is a reset, a zero value, missing samples, staleness, or ingestion failure; compare raw values with resets, rate, and increase where meaningful; explain units and limitations; and keep the investigation read-only.",
+      "expected_output": "The agent finds the healthy 10-second recording rules, proves that skill_eval_sawtooth_counter_total is a time-modulo counter with periodic decreases that resets/rate/increase handle as counter resets, and proves that skill_eval_intermittent_counter_total deliberately stops emitting during part of each cycle so its holes are missing samples rather than zeros or backend failure. It uses one fixed range and compact queries without changing the rules.",
+      "files": [],
+      "expectations": [
+        "Finds both recording rules in group monitoring-skill-metric-temporal-eval and reports their exact expressions, 10-second interval, health, and relevant labels.",
+        "Uses one explicit three-minute range and a 10-second step, or clearly explains an equivalent aligned range, for temporal comparisons.",
+        "Shows that skill_eval_sawtooth_counter_total has repeated raw-value decreases and establishes at least one counter reset with resets or equivalent evidence.",
+        "Uses rate and increase meaningfully for the sawtooth counter and explains that rate is per second while increase is the estimated count over the selected window.",
+        "Does not diagnose the sawtooth decreases as ingestion loss, ordinary zero samples, or an unhealthy recording rule.",
+        "Shows that skill_eval_intermittent_counter_total has missing sample slots while emitted samples remain nonzero or follow the rule expression.",
+        "Distinguishes missing samples from explicit zero values and limits any staleness claim to what the queried range or lookback evidence supports.",
+        "Attributes the intermittent gaps to the expression's periodic gating rather than a VictoriaMetrics outage or failed rule evaluation.",
+        "Uses no more than 10 monitoring MCP calls unless a concrete tool error or conflicting result requires recovery.",
+        "Reports compact reproducible evidence, the time and tenant scope, limitations, and read-only status without modifying either rule."
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "The Grafana panel Everything by source in the dashboard Skill Eval / Expensive Query is reported to time out over its saved 24-hour range. The intended question is only current scrape-target availability by job. Investigate the stored panel configuration and connected monitoring backend, explain why the query is risky, and recommend a semantics-appropriate low-cost replacement. Use query activity, metric-usage, or cardinality evidence when available, but do not execute the original unbounded 24-hour panel query merely to reproduce the timeout. Keep the investigation read-only.",
+      "expected_output": "The agent finds dashboard UID monitoring-skill-eval-expensive-query, captures the all-metrics selector, high-cardinality grouping, 24-hour range, one-second interval, and 86400 max data points, and explains their multiplicative cost. It avoids running the dangerous query, uses bounded query/cardinality evidence, distinguishes configured risk from observed query activity, and recommends count by(job) (up) for the stated current-availability intent without proposing an unnecessary recording rule.",
+      "files": [],
+      "expectations": [
+        "Finds the Skill Eval / Expensive Query dashboard, reports UID monitoring-skill-eval-expensive-query, and identifies panel Everything by source.",
+        "Extracts the exact all-metrics expression and reports the saved 24-hour range, one-second interval, and 86400 maximum data points.",
+        "Resolves Platform Monitoring Prometheus to its actual Prometheus-compatible backend before using direct backend diagnostics.",
+        "Does not execute the original all-metrics expression as a 24-hour one-second range query through Grafana or VictoriaMetrics.",
+        "Explains that the __name__ regex scans all metric names while grouping by metric and multiple high-cardinality source labels preserves a large result set across roughly 86400 evaluation steps.",
+        "Uses safe bounded evidence such as top or active queries, metric usage, TSDB cardinality, series counts, or a narrow up summary instead of downloading an unfiltered matrix.",
+        "Distinguishes static risk in the stored configuration from observed query activity and does not claim the query is currently top or active unless the backend evidence shows it.",
+        "Recommends count by (job) (up), or an equivalently narrow expression, for current scrape-target availability and recommends an instant query or a range resolution appropriate to the actual display need.",
+        "Does not recommend a recording rule without evidence that the corrected aggregation is repeatedly reused or still expensive.",
+        "Uses no more than 10 monitoring MCP calls unless a concrete tool error or discovery ambiguity requires recovery.",
+        "Reports identifiers, datasource, expression, time settings, evidence, limitations, and read-only status."
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "The Request duration panel in the Grafana dashboard Skill Eval / Display Mismatch shows 1.5 ms, but the service owner expects about 1.5 seconds. Investigate the live dashboard and its VictoriaMetrics-backed query. Determine whether the discrepancy comes from the stored metric, query, reduce operation, unit, or another visualization setting, and recommend the smallest correction without changing anything.",
+      "expected_output": "The agent finds dashboard UID monitoring-skill-eval-display-mismatch and panel Request duration, proves that skill_eval_request_duration_seconds currently returns 1.5 and its recording rule expresses seconds, observes lastNotNull is not changing the value, and attributes the 1.5 ms display to the panel unit being configured as milliseconds instead of seconds.",
+      "files": [],
+      "expectations": [
+        "Finds the Skill Eval / Display Mismatch dashboard, reports UID monitoring-skill-eval-display-mismatch, and identifies panel Request duration.",
+        "Extracts the exact metric query, instant-query setting, lastNotNull reduction, and panel unit ms.",
+        "Resolves the Prometheus-compatible datasource to VictoriaMetrics before using direct backend evidence.",
+        "Proves that skill_eval_request_duration_seconds returns 1.5 and identifies its healthy producer expression vector(1.5).",
+        "Distinguishes correct backend data from Grafana presentation and does not diagnose No Data, ingestion loss, or an incorrect reduce result.",
+        "Explains that a seconds-valued metric configured with the ms unit is displayed as 1.5 ms rather than 1.5 s.",
+        "Recommends changing the panel unit to seconds without applying the change.",
+        "Uses no more than 9 monitoring MCP calls unless a concrete tool error or ambiguity requires recovery.",
+        "Reports the time scope, evidence, limitation, and read-only status."
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "SkillEvalRecoveredIncident was reported during the last five minutes, but there is no active alert now. Investigate the vmalert rule and the exact recent metric window, determine whether the condition really became true and then recovered, and explain what can and cannot be concluded about alert state history and notifications. Keep the investigation read-only.",
+      "expected_output": "After the fixture is placed in its recovered phase, the agent finds the healthy periodic vmalert rule, uses a fixed five-minute range to show skill_eval_periodic_incident changing from one to zero, confirms the current expression is false and no active instance exists, and reports recovery without inventing retained alert-state or notification evidence.",
+      "files": [],
+      "expectations": [
+        "Finds SkillEvalRecoveredIncident and its producer rule in group monitoring-skill-historical-alert-eval.",
+        "Reports the exact expressions, 10-second interval, 20-second for duration, rule health, labels, and annotations.",
+        "Uses an explicit five-minute historical range and shows a sustained period with skill_eval_periodic_incident equal to one followed by zero.",
+        "Explains whether the true period was long enough to satisfy the 20-second for duration.",
+        "Checks the current full expression and current active-instance state separately and establishes recovery.",
+        "Does not treat the absent current instance as proof that the alert never fired.",
+        "Does not claim a notification was sent or invent historical activeAt/state data when the available API does not retain it.",
+        "Uses no more than 8 monitoring MCP calls unless a concrete historical ambiguity or tool error requires recovery.",
+        "Reports the exact window, timezone, evidence, limitations, and read-only status."
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "Trace the recording metrics skill_eval:broken:top and skill_eval:cycle:a to their terminal inputs in the live VictoriaMetrics rule set. Determine why neither produces useful data, distinguish a missing producer from a dependency cycle, and report the proven dependency graph, rule health, and limitations without modifying the rules.",
+      "expected_output": "The agent proves that skill_eval:broken:top refers to skill_eval:missing:producer for which no recording rule and no current series exist, while skill_eval:cycle:a and skill_eval:cycle:b refer to each other. It stops safely at the missing producer and cycle, rather than classifying either as a healthy raw-metric chain.",
+      "files": [],
+      "expectations": [
+        "Finds the producer definitions for skill_eval:broken:top, skill_eval:cycle:a, and skill_eval:cycle:b in monitoring-skill-broken-chain-eval.",
+        "Performs an exact producer lookup for skill_eval:missing:producer and establishes that no producing rule exists.",
+        "Checks current data narrowly and establishes that the missing producer and dependent top metric have no current series.",
+        "Builds and reports the cycle skill_eval:cycle:a -> skill_eval:cycle:b -> skill_eval:cycle:a using a visited-name guard.",
+        "Stops traversal at the proven missing producer and cycle without repeatedly querying either dependency.",
+        "Does not call the missing input a raw metric merely because no producer exists and does not claim that healthy rule evaluation means useful output exists.",
+        "Does not run stored-versus-expression matrix comparisons intended for a healthy populated chain when both sides are empty.",
+        "Uses no more than 8 backend calls unless a concrete ambiguity or tool error requires recovery.",
+        "Reports the dependency graphs, rule health, exact expressions, evidence, limitations, and read-only status."
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "Investigate the active Grafana alert SkillEvalGrafanaManagedAlert with rule UID skill-eval-grafana-alert. Determine which alerting system owns and evaluates it, inspect its live instance and rule definition through the connected monitoring MCP servers, explain the query/expression, condition, no-data and execution-error behavior, for duration, labels, annotations, and current state. Do not inspect Kubernetes resources or modify, pause, silence, or route the alert.",
+      "expected_output": "The agent fetches UID skill-eval-grafana-alert through Grafana Unified Alerting MCP, identifies the __expr__ math expression that evaluates to one, explains condition A and the 30-second for duration, and does not search for or conflate it with a vmalert rule. If the MCP omits live instance state, health, or the rule-group evaluation interval, the agent reports those fields as unavailable instead of inspecting Kubernetes or inventing values.",
+      "files": [],
+      "expectations": [
+        "Identifies Grafana Unified Alerting, rather than vmalert, as the evaluator and uses Grafana alerting capabilities for the primary investigation.",
+        "Fetches rule UID skill-eval-grafana-alert through Grafana MCP and inspects its live state or clearly reports when the MCP omits state.",
+        "Reports condition A, the __expr__ math expression 1, and the 30-second for duration; reports the rule-group evaluation interval only if Grafana MCP exposes it, otherwise states that it is unavailable.",
+        "Reports execErrState Error, noDataState NoData, labels, annotations, and whether the rule is paused.",
+        "Explains why the constant nonzero expression satisfies the condition and relates it to pending or firing state.",
+        "Does not search VictoriaMetrics for a same-named vmalert rule after Grafana ownership is established.",
+        "Does not use kubectl, Kubernetes APIs, GrafanaAlertRuleGroup resources, pod access, or direct Grafana endpoints outside MCP.",
+        "Does not claim notification delivery merely because the Grafana alert is firing.",
+        "Uses no more than 8 monitoring MCP calls unless a concrete Grafana tool error or ambiguity requires recovery.",
+        "Reports evidence, limitations, and read-only status without changing alert state or routing."
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Investigate the Grafana dashboard Kubernetes / Nodes Resources and verify its datasource health, then obtain one current VictoriaMetrics up summary. In this run Grafana access is available but the VictoriaMetrics MCP rejects access. Complete every useful read-only Grafana check, explain exactly which backend conclusions remain unverified, and recommend the next access-configuration check without requesting or inferring credentials.",
+      "expected_output": "The agent successfully finds the Grafana dashboard and datasource and reports Grafana-side health, makes one task-specific VictoriaMetrics attempt that receives 401 or 403, then degrades gracefully: it preserves the verified Grafana findings and does not claim direct metric evidence or speculate about authentication.",
+      "files": [],
+      "expectations": [
+        "Successfully finds Kubernetes / Nodes Resources and reports its stable UID through Grafana.",
+        "Identifies the panel or dashboard datasource and reports the Grafana datasource health result.",
+        "Attempts one narrow task-specific up read through the VictoriaMetrics MCP and observes 401 or 403.",
+        "Does not discard or understate the independently verified Grafana evidence because the backend MCP failed.",
+        "Clearly separates Grafana datasource health from unverified direct VictoriaMetrics query results.",
+        "Does not retry the same rejected VictoriaMetrics operation more than once.",
+        "Does not ask for, reveal, invent, or infer credentials, authentication type, or credential placement.",
+        "Recommends checking the VictoriaMetrics MCP connection, server, or proxy access configuration before retrying the original narrow query.",
+        "Keeps the investigation read-only and states its limitations."
+      ]
+    }
+  ]
+}

--- a/.agents/skills/metric-monitoring-via-mcp/evals/evals.json
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/evals.json
@@ -137,7 +137,7 @@
         "Extracts the exact all-metrics expression and reports the saved 24-hour range, one-second interval, and 86400 maximum data points.",
         "Resolves Platform Monitoring Prometheus to its actual Prometheus-compatible backend before using direct backend diagnostics.",
         "Does not execute the original all-metrics expression as a 24-hour one-second range query through Grafana or VictoriaMetrics.",
-        "Explains that the __name__ regex scans all metric names while grouping by metric and multiple high-cardinality source labels preserves a large result set across roughly 86400 evaluation steps.",
+        "Explains that the __name__ regular expression scans all metric names while grouping by metric and multiple high-cardinality source labels preserves a large result set across roughly 86400 evaluation steps.",
         "Uses safe bounded evidence such as top or active queries, metric usage, TSDB cardinality, series counts, or a narrow up summary instead of downloading an unfiltered matrix.",
         "Distinguishes static risk in the stored configuration from observed query activity and does not claim the query is currently top or active unless the backend evidence shows it.",
         "Recommends count by (job) (up), or an equivalently narrow expression, for current scrape-target availability and recommends an instant query or a range resolution appropriate to the actual display need.",

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/README.md
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/README.md
@@ -7,7 +7,7 @@ files for the agent under evaluation.
 ## Mapping
 
 | Eval | Fixture | Expected live state |
-|---|---|---|
+| --- | --- | --- |
 | 1 — recording-rule chain | `recording-rule-chain.yaml` | Two healthy recording rules produce `skill_eval:up:sum_by_job` and `skill_eval:up:double_by_job`. |
 | 3 — dashboard No Data | `dashboard-no-data.yaml` | The panel selects the deliberately absent job value `skill-eval-nonexistent`. |
 | 4 — alert investigation | `alert-rule.yaml` | `SkillEvalApiServerReplicaShortage` becomes pending and then firing when fewer than two healthy `kube-apiserver` targets are visible. |

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/README.md
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/README.md
@@ -1,0 +1,125 @@
+# Monitoring eval fixtures
+
+These manifests create the deterministic live resources required by the
+`metric-monitoring-via-mcp` task evals. They contain no credentials and are not input
+files for the agent under evaluation.
+
+## Mapping
+
+| Eval | Fixture | Expected live state |
+|---|---|---|
+| 1 — recording-rule chain | `recording-rule-chain.yaml` | Two healthy recording rules produce `skill_eval:up:sum_by_job` and `skill_eval:up:double_by_job`. |
+| 3 — dashboard No Data | `dashboard-no-data.yaml` | The panel selects the deliberately absent job value `skill-eval-nonexistent`. |
+| 4 — alert investigation | `alert-rule.yaml` | `SkillEvalApiServerReplicaShortage` becomes pending and then firing when fewer than two healthy `kube-apiserver` targets are visible. |
+| 7 — alert error versus No Data | `alert-error-no-data.yaml` | One alert rule has a runtime vector-matching error; the other is healthy but has no matching input series. |
+| 8 — counter reset and gaps | `metric-temporal-semantics.yaml` | One synthetic counter resets every minute; another is absent during a repeatable part of each 30-second cycle. |
+| 9 — expensive query | `dashboard-expensive-query.yaml` | A panel stores an intentionally broad all-metrics query over 24 hours with a one-second interval. |
+| 10 — display mismatch | `dashboard-display-mismatch.yaml` | The backend stores 1.5 seconds while the Grafana panel formats the value as milliseconds. |
+| 11 — recovered incident | `historical-recovered-alert.yaml` | A periodic signal is true for 90 seconds and then recovers, leaving historical metric evidence after the active instance disappears. |
+| 12 — broken rule dependencies | `recording-rule-broken-chain.yaml` | One chain terminates at a missing producer and another contains a two-rule cycle. |
+| 13 — Grafana-managed alert | `grafana-managed-alert.yaml` | A Grafana expression rule evaluates to one and becomes active independently of vmalert. |
+
+Eval 5 was retired because logs and traces are outside the skill scope. Evals 2,
+6, and 14 do not use Kubernetes fixtures. Eval 2 requires the deployment's
+normal Grafana and VictoriaMetrics MCP access. Eval 6 must be launched with the
+MCP authentication environment variables intentionally absent so that the
+connections return `401` or `403`. Eval 14 uses normal Grafana access but must
+launch only the VictoriaMetrics MCP without its required authentication
+environment. Eval 15 was retired because its required ServiceMonitor, Service,
+EndpointSlice, and vmagent target evidence was available only through Kubernetes
+access in this deployment, which is outside the MCP-only skill scope. Never put
+credentials in this directory.
+
+## Prerequisites
+
+- Namespace `monitoring` exists.
+- Prometheus Operator `monitoring.coreos.com/v1` `PrometheusRule` CRD exists.
+- Grafana Operator `grafana.integreatly.org/v1beta1` `GrafanaDashboard` CRD exists.
+- A Grafana instance matches labels `app.kubernetes.io/component=grafana` and
+  `app.kubernetes.io/part-of=monitoring`.
+- A datasource named `Platform Monitoring Prometheus` exists.
+- vmalert selects `PrometheusRule` resources in the `monitoring` namespace and
+  evaluates them against a backend containing the raw `up` metric.
+- Grafana Unified Alerting and `GrafanaAlertRuleGroup` synchronization are
+  enabled for eval 13.
+
+The fixture harness may use Kubernetes manifests to create deterministic live
+state, but the agent under evaluation must receive evidence only through the
+connected Grafana and VictoriaMetrics MCP servers. Do not grant it `kubectl`,
+Kubernetes API, pod exec, service-proxy, or repository-fixture access.
+
+## Apply
+
+Apply only the fixtures needed by the selected eval, for example:
+
+```bash
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/recording-rule-chain.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-no-data.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/alert-rule.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/alert-error-no-data.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/metric-temporal-semantics.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-expensive-query.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-display-mismatch.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/historical-recovered-alert.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/recording-rule-broken-chain.yaml
+kubectl apply -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/grafana-managed-alert.yaml
+```
+
+Do not start the eval immediately. Poll the live systems until:
+
+- both recorded metrics return data and both producer rules report healthy;
+- each GrafanaDashboard reports `DashboardSynchronized=True` and can be found by
+  its expected title through mcp-grafana;
+- the alert instance is visible through mcp-victoriametrics and has reached the
+  state expected by the eval. With a 30-second evaluation interval and `for: 1m`,
+  this normally requires more than one minute.
+- for eval 7, both rules are visible in group
+  `monitoring-skill-alert-failure-eval`, `SkillEvalEvaluationError` has unhealthy
+  rule health and a nonempty vector-matching error, while
+  `SkillEvalNoInputData` is healthy with zero output samples and no active alert
+  instance.
+- for eval 8, both recording rules are healthy and have evaluated for at least
+  two minutes. Over a three-minute range, `skill_eval_sawtooth_counter_total`
+  has at least one reset and `skill_eval_intermittent_counter_total` has missing
+  evaluation slots.
+- for eval 9, the GrafanaDashboard reports `DashboardSynchronized=True`, its
+  title is discoverable through mcp-grafana, and nobody has opened the panel or
+  otherwise executed its intentionally broad stored query before the eval.
+- for eval 10, both the recording rule and dashboard are synchronized and the
+  metric returns `1.5` at the current time.
+- for eval 11, the rules have evaluated for more than five minutes. Start the
+  agent only while `skill_eval_periodic_incident` currently equals zero and the
+  previous five-minute window contains a continuous true segment of at least
+  20 seconds; record the exact launch time for grading.
+- for eval 12, all three rule definitions are visible and none of the three
+  recorded outputs currently returns samples.
+- for eval 13, `GrafanaAlertRuleGroup` reports successful synchronization and
+  Grafana Alerting exposes rule UID `skill-eval-grafana-alert` as pending or
+  firing. If the deployment does not expose Grafana alert reads through MCP,
+  mark the fixture unsupported instead of grading the agent on invented data.
+
+The alert threshold assumes this eval environment exposes fewer than two
+healthy `kube-apiserver` `up` series. Verify that assumption before grading; if
+the environment is highly available, use a separate isolated fixture namespace
+or adjust the fixture and matching expected output together.
+
+## Cleanup
+
+Delete the same manifests after the eval:
+
+```bash
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/recording-rule-chain.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-no-data.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/alert-rule.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/alert-error-no-data.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/metric-temporal-semantics.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-expensive-query.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-display-mismatch.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/historical-recovered-alert.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/recording-rule-broken-chain.yaml
+kubectl delete --ignore-not-found -f .agents/skills/metric-monitoring-via-mcp/evals/fixtures/grafana-managed-alert.yaml
+```
+
+The shared label key `skill-eval` and the purpose annotation make these resources
+easy to identify, but cleanup uses exact manifest names to avoid deleting other
+tests.

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/alert-error-no-data.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/alert-error-no-data.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: monitoring-skill-eval-alert-failures
+  namespace: monitoring
+  labels:
+    skill-eval: alert-error-no-data
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-7
+spec:
+  groups:
+    - name: monitoring-skill-alert-failure-eval
+      interval: 30s
+      rules:
+        - alert: SkillEvalEvaluationError
+          expr: (up + on(job) up) > 0
+          for: 1m
+          labels:
+            severity: warning
+            skill_eval: "true"
+            scenario: evaluation-error
+          annotations:
+            summary: Skill eval alert with a runtime vector-matching error
+            description: The expression deliberately creates duplicate matches for job labels.
+        - alert: SkillEvalNoInputData
+          expr: sum(up{job="skill-eval-nonexistent"}) > 0
+          for: 1m
+          labels:
+            severity: warning
+            skill_eval: "true"
+            scenario: no-input-data
+          annotations:
+            summary: Skill eval alert with no matching input series
+            description: The expression is valid but its selector deliberately matches no current series.

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/alert-rule.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/alert-rule.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: monitoring-skill-eval-alert
+  namespace: monitoring
+  labels:
+    skill-eval: alert-investigation
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-4
+spec:
+  groups:
+    - name: monitoring-skill-alert-eval
+      interval: 30s
+      rules:
+        - alert: SkillEvalApiServerReplicaShortage
+          expr: (sum(up{job="kube-apiserver"}) or vector(0)) < 2
+          for: 1m
+          labels:
+            severity: warning
+            skill_eval: "true"
+          annotations:
+            summary: Skill eval API server replica shortage
+            description: The observed kube-apiserver target count is below the fixture threshold of two.

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-display-mismatch.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-display-mismatch.yaml
@@ -1,0 +1,70 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: monitoring-skill-eval-display-mismatch
+  namespace: monitoring
+  labels:
+    skill-eval: dashboard-display-mismatch
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-10
+spec:
+  groups:
+    - name: monitoring-skill-display-mismatch-eval
+      interval: 30s
+      rules:
+        - record: skill_eval_request_duration_seconds
+          expr: vector(1.5)
+          labels:
+            skill_eval: "true"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: monitoring-skill-eval-display-mismatch
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: monitoring
+    skill-eval: dashboard-display-mismatch
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-10
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/part-of: monitoring
+  json: |
+    {
+      "id": null,
+      "uid": "monitoring-skill-eval-display-mismatch",
+      "title": "Skill Eval / Display Mismatch",
+      "tags": ["self-monitor", "skill-eval"],
+      "editable": false,
+      "timezone": "utc",
+      "schemaVersion": 41,
+      "version": 1,
+      "time": {"from": "now-15m", "to": "now"},
+      "panels": [
+        {
+          "id": 1,
+          "title": "Request duration",
+          "description": "The source metric is measured in seconds.",
+          "type": "stat",
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "fieldConfig": {"defaults": {"unit": "ms", "decimals": 1}, "overrides": []},
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$datasource"},
+              "editorMode": "code",
+              "expr": "skill_eval_request_duration_seconds",
+              "instant": true,
+              "range": false,
+              "refId": "A"
+            }
+          ]
+        }
+      ],
+      "templating": {"list": [{"name": "datasource", "type": "datasource", "query": "prometheus", "current": {"text": "Platform Monitoring Prometheus"}, "options": []}]},
+      "annotations": {"list": []},
+      "links": []
+    }

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-expensive-query.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-expensive-query.yaml
@@ -1,0 +1,96 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: monitoring-skill-eval-expensive-query
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: monitoring
+    skill-eval: expensive-query
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-9
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/part-of: monitoring
+  json: |
+    {
+      "id": null,
+      "uid": "monitoring-skill-eval-expensive-query",
+      "title": "Skill Eval / Expensive Query",
+      "tags": ["self-monitor", "skill-eval"],
+      "editable": false,
+      "timezone": "utc",
+      "schemaVersion": 41,
+      "version": 1,
+      "refresh": "",
+      "time": {
+        "from": "now-24h",
+        "to": "now"
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Everything by source",
+          "description": "Intentionally broad eval query. The intended question is current scrape-target availability by job.",
+          "type": "timeseries",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum by (__name__, namespace, pod, container, instance, job) ({__name__=~\".+\"})",
+              "legendFormat": "{{__name__}} / {{job}} / {{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "maxDataPoints": 86400,
+          "interval": "1s"
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "datasource",
+            "label": "Datasource",
+            "type": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "current": {
+              "text": "Platform Monitoring Prometheus"
+            },
+            "options": []
+          }
+        ]
+      },
+      "annotations": {
+        "list": []
+      },
+      "links": []
+    }

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-no-data.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/dashboard-no-data.yaml
@@ -1,0 +1,114 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: monitoring-skill-eval-no-data
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: monitoring
+    skill-eval: dashboard-no-data
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-3
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/part-of: monitoring
+  json: |
+    {
+      "id": null,
+      "uid": "monitoring-skill-eval-no-data",
+      "title": "Skill Eval / Missing Data",
+      "tags": ["self-monitor", "skill-eval"],
+      "editable": false,
+      "timezone": "browser",
+      "schemaVersion": 41,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Missing targets",
+          "type": "timeseries",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "up{job=\"$job\"}",
+              "legendFormat": "{{job}} / {{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        }
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "datasource",
+            "label": "Datasource",
+            "type": "datasource",
+            "query": "prometheus",
+            "refresh": 1,
+            "current": {
+              "text": "Platform Monitoring Prometheus"
+            },
+            "options": []
+          },
+          {
+            "name": "job",
+            "label": "Job",
+            "type": "custom",
+            "query": "skill-eval-nonexistent",
+            "current": {
+              "text": "skill-eval-nonexistent",
+              "value": "skill-eval-nonexistent"
+            },
+            "options": [
+              {
+                "selected": true,
+                "text": "skill-eval-nonexistent",
+                "value": "skill-eval-nonexistent"
+              }
+            ]
+          }
+        ]
+      },
+      "annotations": {
+        "list": []
+      },
+      "links": []
+    }

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/grafana-managed-alert.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/grafana-managed-alert.yaml
@@ -1,0 +1,48 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: monitoring-skill-eval-grafana-alert
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: monitoring
+    skill-eval: grafana-managed-alert
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-13
+spec:
+  folderUID: general
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/part-of: monitoring
+  interval: 30s
+  name: monitoring-skill-grafana-alert-eval
+  rules:
+    - uid: skill-eval-grafana-alert
+      title: SkillEvalGrafanaManagedAlert
+      condition: A
+      data:
+        - refId: A
+          datasourceUid: __expr__
+          relativeTimeRange:
+            from: 0
+            to: 0
+          model:
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: "1"
+            intervalMs: 1000
+            maxDataPoints: 43200
+            refId: A
+            type: math
+      execErrState: Error
+      for: 30s
+      noDataState: NoData
+      isPaused: false
+      labels:
+        severity: warning
+        skill_eval: "true"
+        evaluator: grafana
+      annotations:
+        summary: Synthetic Grafana-managed alert
+        description: A Grafana expression deliberately evaluates to one.

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/historical-recovered-alert.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/historical-recovered-alert.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: monitoring-skill-eval-historical-alert
+  namespace: monitoring
+  labels:
+    skill-eval: historical-recovered-alert
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-11
+spec:
+  groups:
+    - name: monitoring-skill-historical-alert-eval
+      interval: 10s
+      rules:
+        - record: skill_eval_periodic_incident
+          expr: vector((time() % 300) < bool 90)
+          labels:
+            skill_eval: "true"
+            scenario: historical-recovery
+        - alert: SkillEvalRecoveredIncident
+          expr: skill_eval_periodic_incident > 0
+          for: 20s
+          labels:
+            severity: warning
+            skill_eval: "true"
+          annotations:
+            summary: Synthetic incident that recovers during each five-minute cycle
+            description: The condition is true for the first 90 seconds of each cycle.

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/metric-temporal-semantics.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/metric-temporal-semantics.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: monitoring-skill-eval-metric-temporal
+  namespace: monitoring
+  labels:
+    skill-eval: metric-temporal-semantics
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-8
+spec:
+  groups:
+    - name: monitoring-skill-metric-temporal-eval
+      interval: 10s
+      rules:
+        - record: skill_eval_sawtooth_counter_total
+          expr: vector(time() % 60)
+          labels:
+            skill_eval: "true"
+            scenario: periodic-reset
+        - record: skill_eval_intermittent_counter_total
+          expr: vector(time() % 60) and (vector(time() % 30) >= 10)
+          labels:
+            skill_eval: "true"
+            scenario: periodic-gap

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/recording-rule-broken-chain.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/recording-rule-broken-chain.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: monitoring-skill-eval-broken-chain
+  namespace: monitoring
+  labels:
+    skill-eval: recording-rule-broken-chain
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-12
+spec:
+  groups:
+    - name: monitoring-skill-broken-chain-eval
+      interval: 30s
+      rules:
+        - record: skill_eval:broken:top
+          expr: skill_eval:missing:producer * 2
+          labels:
+            skill_eval: "true"
+            scenario: missing-producer
+        - record: skill_eval:cycle:a
+          expr: skill_eval:cycle:b + 1
+          labels:
+            skill_eval: "true"
+            scenario: cycle
+        - record: skill_eval:cycle:b
+          expr: skill_eval:cycle:a + 1
+          labels:
+            skill_eval: "true"
+            scenario: cycle

--- a/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/recording-rule-chain.yaml
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/fixtures/recording-rule-chain.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: monitoring-skill-eval-recording-chain
+  namespace: monitoring
+  labels:
+    skill-eval: recording-rule-chain
+  annotations:
+    skill-eval.qubership.org/purpose: work-with-monitoring-eval-1
+spec:
+  groups:
+    - name: monitoring-skill-chain-eval
+      interval: 30s
+      rules:
+        - record: skill_eval:up:sum_by_job
+          expr: sum by (job) (up)
+          labels:
+            skill_eval: "true"
+        - record: skill_eval:up:double_by_job
+          expr: skill_eval:up:sum_by_job * 2
+          labels:
+            skill_eval: "true"

--- a/.agents/skills/metric-monitoring-via-mcp/evals/trigger-evals.json
+++ b/.agents/skills/metric-monitoring-via-mcp/evals/trigger-evals.json
@@ -1,0 +1,86 @@
+[
+  {
+    "query": "In the Grafana dashboard Kubernetes / Nodes Resources, the CPU panel suddenly shows No data. Find its datasource, reconstruct the effective query with resolved variables, and check the last 20 minutes of data.",
+    "should_trigger": true
+  },
+  {
+    "query": "Trace metric namespace:container_cpu_usage:sum_rate through every recording rule to raw metrics in VictoriaMetrics and check whether stored values still match the expressions.",
+    "should_trigger": true
+  },
+  {
+    "query": "The KubePodCrashLooping alert has been pending for 15 minutes. Use the available monitoring MCP servers to determine why it remains pending and whether the for condition has been satisfied.",
+    "should_trigger": true
+  },
+  {
+    "query": "Investigate why http_requests_total exists for namespace=dev but has disappeared for namespace=prod. Check labels, freshness, the current value, and a one-hour range.",
+    "should_trigger": true
+  },
+  {
+    "query": "Find the Grafana-managed alert Checkout latency high, inspect its rule and datasource, and explain whether NoData or the threshold caused its current state.",
+    "should_trigger": true
+  },
+  {
+    "query": "Use kubectl to inspect ServiceMonitor payments-api, its selected Service and EndpointSlices, and the vmagent custom resource to find where Kubernetes discovery drops it.",
+    "should_trigger": false
+  },
+  {
+    "query": "Using only the connected VictoriaMetrics MCP, inspect active and dropped vmagent targets for payments-api and explain the scrape health, last error, and any relabeling evidence the MCP exposes.",
+    "should_trigger": true
+  },
+  {
+    "query": "The recording rule job:http_errors:rate5m reports health=error. Find its lastError, evaluate the expression in parts, and determine whether the cause is syntax, label matching, or a missing input metric.",
+    "should_trigger": true
+  },
+  {
+    "query": "Which current targets contribute to up{job=\"kubelet\"} in this deployment, and were any series stale or missing during the last 30 minutes? Use compact live evidence.",
+    "should_trigger": true
+  },
+  {
+    "query": "The dashboard variable cluster is set to east but the panel shows west data. Inspect the saved variables, panel query, datasource and returned labels to locate the mismatch.",
+    "should_trigger": true
+  },
+  {
+    "query": "vmalert says DiskSpaceLow is firing, Alertmanager has multiple instances. Verify the evaluated expression and explain which labels created the separate alert instances.",
+    "should_trigger": true
+  },
+  {
+    "query": "Create a new GrafanaDashboard custom resource for HTTP latency with p50, p95, and p99 panels, and add it to the operator Helm chart.",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix the Grafana reconciler in controllers/grafana: after a custom resource update its status does not change and the unit test fails.",
+    "should_trigger": false
+  },
+  {
+    "query": "Explain with a self-contained example how rate() differs from increase() in PromQL. No access to a live monitoring environment is needed.",
+    "should_trigger": false
+  },
+  {
+    "query": "Review this local dashboard JSON file for schemaVersion compatibility and format it; don't connect to Grafana or query any live datasource.",
+    "should_trigger": false
+  },
+  {
+    "query": "The Loki Logs panel unexpectedly returns no results. Inspect its LogQL query and determine why no application logs were returned.",
+    "should_trigger": false
+  },
+  {
+    "query": "Write PrometheusRule YAML for a new SLO burn-rate alert and add it to the charts, but do not inspect or validate anything in the live cluster.",
+    "should_trigger": false
+  },
+  {
+    "query": "Add support for grafana.integreatly.org/v1beta1 GrafanaDatasource resources to the Go operator and regenerate the CRDs.",
+    "should_trigger": false
+  },
+  {
+    "query": "Design a set of RED metrics and SLOs for a new checkout API; the monitoring environment has not been deployed yet.",
+    "should_trigger": false
+  },
+  {
+    "query": "Configure the mcp-grafana server in Codex so its authorization header is taken from an environment variable.",
+    "should_trigger": false
+  },
+  {
+    "query": "Migrate the existing alert rules from Jsonnet to Helm templates while preserving their names and labels. Do not investigate the live system.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/metric-monitoring-via-mcp/references/investigation-playbooks.md
+++ b/.agents/skills/metric-monitoring-via-mcp/references/investigation-playbooks.md
@@ -1,0 +1,471 @@
+# Monitoring Investigation Playbooks
+
+Use the playbook matching the user's outcome. Skip a step only when its answer
+is already established by evidence.
+
+## Contents
+
+- [Dashboard or Panel](#dashboard-or-panel)
+- [Partial MCP Access or Authorization Failure](#partial-mcp-access-or-authorization-failure)
+- [Metric](#metric)
+- [Alert State or Evaluation Failure](#alert-state-or-evaluation-failure)
+- [Scrape Discovery or Relabeling](#scrape-discovery-or-relabeling)
+- [Recording Rule or Recorded Metric](#recording-rule-or-recorded-metric)
+- [Dashboard Shows No Data](#dashboard-shows-no-data)
+- [Noisy or Expensive Query](#noisy-or-expensive-query)
+
+## Partial MCP Access or Authorization Failure
+
+When a task intentionally checks multiple MCP connections and one rejects
+access, preserve evidence from the working connection but do not widen that
+side to compensate for the failure. Before calling tools, assign every requested
+outcome to exactly one slot. For a dashboard, datasource-health, and
+direct-backend access check, use this closed ledger:
+
+1. Search for the exact dashboard once and record its stable UID.
+2. Read one panel or dashboard datasource reference only if the search response
+   does not identify the concrete datasource. If panels refer to a datasource
+   variable, read the dashboard's complete, small templating list once and
+   filter it locally. Do not first try a JSONPath predicate and then fetch the
+   same list again when server-side predicate support is uncertain.
+3. Read datasource detail only for identity fields still missing, and call its
+   health endpoint once when health is requested. If one datasource response
+   supplies both identity and health, it fills both slots.
+4. Make exactly one task-specific direct-backend query. A `401` or `403` fills
+   this slot as an access result even though it supplies no metric value.
+5. Stop and report which backend value remains unverified. Do not resolve
+   unrelated variables, enumerate labels or metric names, execute a saved or
+   arbitrary panel, or replay the rejected expression through Grafana merely to
+   compensate for the failure. Use a working-connection fallback only when the
+   user explicitly requests one.
+
+Phrases such as "complete every useful check" remain bounded by these named
+outcomes, not every adjacent dashboard fact. This path normally takes 3-5
+Grafana calls plus the single rejected backend call; a blank response may use
+one recovery slot, but an authorization rejection may not.
+
+## Dashboard or Panel
+
+1. Search dashboards by title, tags, or folder.
+2. Fetch the selected dashboard by UID.
+3. Find the panel by title or ID.
+4. Record its datasource UID and type, targets, variables, transformations,
+   units, thresholds, and time overrides.
+5. Resolve variable values for the requested cluster, namespace, workload, or
+   other scope.
+6. Execute the stored panel query if supported; otherwise execute its expression
+   against the identified datasource.
+7. Compare returned values with panel transformations, units, and thresholds.
+8. Report whether the issue is in the data, selector or variable resolution,
+   datasource, transformation, or visualization configuration.
+
+For a panel whose backend value exists but its displayed magnitude, unit, or
+threshold interpretation looks wrong, use this bounded ledger:
+
+1. Search the exact dashboard once, then read the target panel configuration
+   through one narrow path. Prefer one panel property that includes target,
+   datasource, transformations, field unit, reduction, thresholds, and time
+   overrides. Do not also read the dashboard summary, panel index, full
+   dashboard, and the same panel through a second path.
+2. Resolve the datasource through one detail call unless the panel response
+   already supplies its UID, type, and backend. Execute the stored query once in
+   its saved instant or range mode; this establishes the value entering panel
+   processing.
+3. Establish semantic type and unit with at most one metadata lookup. A suffix
+   such as `_seconds`, dashboard prose, or a legend is a useful hint but not a
+   substitute for source evidence when unit or scaling is the disputed fact.
+4. If metadata is absent or conflicts and the queried name may be a recorded
+   metric, make one exact producer-rule lookup. Record its expression and
+   health, and check whether it scales, normalizes, aggregates, or converts the
+   input. Do not replace this lookup with broad metric discovery or multiple
+   alternative value queries.
+5. Compare the one returned value with transformations, reduction, unit,
+   decimals, thresholds, and overrides locally. Add one direct-backend range
+   only when temporal stability or a Grafana/backend disagreement is material;
+   do not run instant, range, `last_over_time`, and a second interface merely to
+   prove the same value.
+6. Stop when source semantics, query value, and panel processing identify the
+   first conversion or presentation mismatch. Report any remaining semantic
+   uncertainty rather than inferring authority from the metric name alone.
+
+This normally takes 5-8 monitoring calls: dashboard discovery, one panel read,
+one datasource read, one stored-query execution, metadata and—only when that
+metadata is insufficient—one producer lookup, plus at most one justified
+backend comparison. Leave one recovery slot instead of filling every optional
+branch.
+
+## Metric
+
+1. Search metric names with the narrowest known prefix or pattern.
+2. Read metric metadata to determine type, unit, and meaning.
+3. Inspect label names, then values for only the labels needed to scope the
+   query.
+4. Run a narrow instant query to confirm current availability.
+5. Run a range query for the requested interval using an appropriate step.
+6. Compare related series using identical selectors and time settings.
+7. Explain the result, including aggregation, rate or increase semantics,
+   counter resets, gaps, staleness, and units when relevant.
+
+For a bounded temporal comparison of a few known metrics, use this evidence
+ledger:
+
+1. Fetch all known recording-rule definitions in one filtered rule call when
+   the tool accepts multiple names. The definitions already establish
+   expressions, interval, health, and rule-added labels; do not repeat one call
+   per metric.
+2. Read metric metadata only when type, unit, or meaning remains material and
+   cannot be established from the rule or user context. Do not make identical
+   metadata calls for every generated metric merely to confirm that metadata is
+   absent.
+3. Freeze one range and use one combined range query for raw values plus the
+   decisive reset, rate, increase, sample-count, zero, or stale-marker checks.
+   Add distinguishing labels so multiple metrics and checks can share the call.
+4. Use at most one compact instant query when the range response does not
+   establish current presence or freshness. Do not first request range vectors
+   through an instant-query endpoint and then repeat them with a range query.
+5. Stop when rule health and expression explain the observed pattern and the
+   stored range agrees. Remote-write health, a second expression comparison, or
+   another raw matrix is justified only by conflicting or missing evidence.
+
+This normally takes 3-6 backend calls. Documentation is a recovery path for an
+unresolved function or response format, not a routine confirmation of reset or
+staleness semantics already demonstrated by query results.
+
+## Alert State or Evaluation Failure
+
+1. Determine whether Grafana Alerting or vmalert evaluates the alert.
+2. Fetch the rule definition and check for an active alert instance. An absent
+   instance does not by itself distinguish a false condition, valid empty
+   result, evaluation error, or expired alert.
+3. Record state, health, last error, labels, annotations, expression, threshold,
+   evaluation interval, `for` duration, and error or no-data behavior. Give each
+   inspected rule one compact definition row in the report. Include an empty
+   last error explicitly, and preserve every MCP-returned annotation field that
+   carries user-authored meaning. When both `summary` and `description` exist,
+   label and include both; do not select one or replace either with a diagnosis
+   or inferred intent. This keeps severity, scope, and stated meaning attached
+   to the correct rule without dumping unrelated metadata.
+4. Freeze one explicit time and evaluate the full expression there. Classify
+   the outcome before drilling down:
+   - unhealthy rule or query error: evaluation failed and produced no alert
+     vector; inspect the error and only the operands needed to isolate it;
+   - healthy rule and successful empty vector: valid no-result evaluation;
+     inspect the narrow selector or aggregation that removed the input;
+   - nonempty vector: compare its values with the threshold and `for` duration.
+5. Evaluate meaningful operands or intermediate aggregations separately. Use a
+   combined labelled count or summary when it can prove both input availability
+   and selector mismatch without downloading full vectors.
+6. Check whether missing data, changed labels, delayed ingestion, vector
+   matching, or datasource errors explain the state. Do not label a healthy
+   empty vector as an evaluator failure, and do not label an unhealthy rule as
+   ordinary No Data or a false threshold.
+7. Recommend the smallest correction for the established cause. Do not execute
+   alternative corrected expressions merely to demonstrate that they parse
+   unless the user asks to verify a proposed correction or evidence remains
+   ambiguous.
+8. Report evidence for why the alert is firing, pending, inactive, absent, or
+   unknown, including the point-in-time or historical limitation.
+
+For a comparison of two known vmalert rules, normally use one filtered rule
+lookup, one full-expression query per rule, up to two compact input summaries,
+and one active-instance lookup. Reuse rule fields already returned. A failed
+paginated alert lookup may be retried once without pagination, but do not try
+multiple limits. Exceed this 5-6 call ledger only for a concrete tool error,
+conflicting evidence, or required historical investigation.
+
+For a reported incident that has already recovered, freeze the reported
+incident window before checking the current state. Query the full expression
+and decisive operands over that historical window, then use one current check
+of the exact complete alert expression to establish recovery. A raw input value
+or empty current-instance list does not replace that expression check. If the
+alert expression references a metric that could be recorded, use one exact
+producer-rule lookup and report its expression and health when found; otherwise
+the investigation proves the input's values but not its generation semantics.
+A missing current alert instance is evidence only about the current state; it
+is not proof that the alert never fired. If the alerting API exposes no retained
+state history, say so and use rule definitions plus historical metric values
+without inventing `activeAt`, notification, or continuity evidence.
+
+Use a closed recovered-incident ledger: one alert-rule lookup; one exact
+producer lookup when the input may be recorded; one historical range combining
+the full expression and decisive input; one exact current full-expression
+query; and one current active-instance lookup. Add at most one historical alert
+state range when it materially distinguishes inferred condition truth from an
+observed pending or firing state. Reuse the original rule definition and current
+check even if wall-clock time advances during the investigation; report a newly
+started incident or changed snapshot instead of repeating the rule lookup or
+the same full-expression query at successive times.
+
+For one named Grafana-managed alert, use this evidence ledger:
+
+1. Perform one exact or name-filtered Grafana alert-rule lookup. If it returns a
+   matching UID and definition, ownership is established; do not add a vmalert
+   lookup. If the response is `null`, blank, or lacks the named rule, make at
+   most one unfiltered Grafana rule-list call because some server versions do
+   not implement filters consistently. Do not try separate firing, pending,
+   all-state, and limit variants.
+2. Reuse the list response when it already contains condition, queries,
+   interval, `for`, no-data/error behavior, labels, annotations, and paused
+   state. Otherwise fetch that UID once. Do not list all rules or all alert
+   states after the exact match.
+3. Use current instances or state included by the Grafana alerting tool. When
+   state fields are absent, choose exactly one supported fallback:
+   - one Grafana alert-instance or Alertmanager read through the connected MCP;
+   - or one compact query of Grafana alerting metrics that can be tied to the
+     rule UID or name.
+   Do not combine global metric inventory, individual state queries, a range
+   query, and an internal state-store read. If no supported fallback identifies
+   the instance, report current state as unavailable while still explaining the
+   rule definition.
+4. Use provenance or synchronization fields only when a connected Grafana MCP
+   response includes them. Do not inspect `GrafanaAlertRuleGroup` resources,
+   Kubernetes CRDs, pods, internal databases, repository manifests, or direct
+   Grafana endpoints outside MCP. If Grafana lookups do not identify the rule,
+   one exact vmalert lookup may test the remaining evaluator hypothesis; if it
+   is also empty, report ownership as unresolved.
+5. For `__expr__` queries, evaluate the stored math or reduce condition locally
+   when its inputs are already literal or present in the rule response. Do not
+   query VictoriaMetrics for an expression that has no VictoriaMetrics input.
+6. Stop after definition and one current-state path agree. A normal path is 3-6
+   MCP calls; reserve a seventh for one failed or blank state response. When
+   state or provenance remains unavailable after the one MCP fallback, say so—
+   the evidence ledger is complete even though the desired fact is unavailable.
+
+## Scrape Discovery or Relabeling
+
+1. Inspect the target and service-discovery capabilities actually exposed by
+   `mcp-victoriametrics`. If neither is available, state that this skill cannot
+   localize the missing target and stop the discovery branch. Do not use
+   `kubectl`, Kubernetes APIs, service proxies, pod exec, or local manifests.
+2. Request active and dropped targets once, scoped by the narrowest stable
+   identity the MCP accepts. Prefer scrape-pool/job identity or discovered
+   resource labels over a mutable final `job` label. Reuse this response rather
+   than retrying with progressively looser filters.
+3. Separate discovered labels from final labels. Record any MCP-returned scrape
+   URL, health, last scrape, last error, dropped reason, and relabeling or scrape
+   configuration. Do not claim that a collector selected a scrape resource, a
+   Service matched, or an endpoint was ready unless the MCP response explicitly
+   proves that fact.
+4. Replay relabeling only when the MCP exposes both the relevant ordered rules
+   and their source labels, or an explicit dropped-target explanation. Account
+   for defaults, separators, missing labels, and earlier mutations. Otherwise
+   report that relabel causality is unavailable rather than inferring it from a
+   suggestive label value.
+5. For an active target, use its MCP-reported health and error to distinguish a
+   scrape failure from discovery loss. Add at most one narrow `up` query for the
+   same final labels when stored presence is material. If `up` exists but a
+   requested metric does not, diagnose metric relabeling only when MCP-returned
+   configuration proves it; otherwise keep sample filtering and endpoint output
+   as unresolved alternatives.
+6. Check remote-write or ingestion evidence only after MCP data proves a
+   successful scrape retained the relevant sample. Stop at the first stage the
+   MCP evidence actually establishes and state every earlier configuration
+   stage that remains outside visibility.
+
+This normally takes 2-5 MCP calls: one capability or target-discovery read, one
+active-and-dropped target snapshot, an optional returned-config read, one narrow
+metric query, and at most one justified ingestion check. A missing MCP target
+capability is a valid limitation, not permission to switch tools.
+
+## Recording Rule or Recorded Metric
+
+1. Search for the producer by exact output metric name. Use a filtered rule
+   lookup when available; scan the full inventory only if filtering is
+   unavailable or multiple producers must be disambiguated.
+2. Record the group, expression, rule-added labels, evaluation interval, health,
+   last error, and last evaluation. The successful rule read also proves access,
+   so do not add a separate connectivity query.
+3. Parse metric references from the expression. Search each candidate by exact
+   rule output name, track visited names, and build the dependency chain before
+   running range queries. Perform this exact producer lookup for the terminal
+   candidate too: only an empty producer result establishes that it is raw or
+   has a missing rule. Do not classify a familiar metric such as `up` as raw by
+   convention. Stop after the verified empty lookup or at a cycle.
+4. Confirm current availability with one combined instant summary when the
+   backend supports MetricsQL. Label and join per-level counts, sums, minima, or
+   maxima in one query instead of fetching each full vector separately. Query a
+   representative series only if labels or values need drill-down. Choose one
+   composition form (`or` with distinguishing labels, or `union(...)`) before
+   calling the backend. If the response is nonempty and contains every expected
+   `level` or `source` label, accept it: do not retry with the other composition
+   form or query the same stored and expression vectors individually.
+   Before range comparison, classify each branch as populated, one-sided, or
+   empty. When both a stored output and its expression are proven empty, their
+   equality is vacuous: report the empty branch and its dependency defect, then
+   skip mismatch matrices, freshness checks, and healthy-chain validation for
+   that branch. When only one side exists, retain the missing-series comparison
+   because the asymmetry is evidence.
+5. Freeze one explicit range and use the rule interval as the step for every
+   comparison. Compare stored output with its expression using server-side
+   mismatch counts where vector matching permits it:
+   - count unequal values after ignoring only rule-added labels;
+   - count stored series absent from the expression;
+   - count expression series absent from the stored output.
+   Combine the three checks for one level into a single MetricsQL range query.
+   `or vector(0)` makes a successful zero-mismatch result explicit, while the
+   `check` label keeps the three results distinct:
+
+   ```promql
+   label_set(
+     (count(<stored> != ignoring(<rule_added_labels>) (<expression>)) or vector(0)),
+     "check", "unequal"
+   )
+   or label_set(
+     (count(<stored> unless ignoring(<rule_added_labels>) (<expression>)) or vector(0)),
+     "check", "stored_missing"
+   )
+   or label_set(
+     (count((<expression>) unless ignoring(<rule_added_labels>) <stored>) or vector(0)),
+     "check", "expression_missing"
+   )
+   ```
+
+   Omit `ignoring(...)` when the rule adds no labels. If either side is a scalar
+   or vector matching is otherwise invalid, use equivalent server-side
+   aggregations or narrow both sides to the same representative label set.
+   Use one combined range call per recorded level; split it only when the
+   backend rejects the combined syntax or a nonzero check requires drill-down.
+6. If all counts are zero, record the counts and avoid downloading full output
+   and expression matrices. If matching is ambiguous or a count is nonzero,
+   fetch only the affected label set or one representative series before
+   widening the query.
+7. Check freshness with one combined instant age query for all levels, or a
+   server-side `tlast_over_time` aggregation when actual sample time is
+   available. A range query's timestamps may be evaluation grid timestamps
+   rather than raw storage timestamps, so do not infer stored sample lag from
+   them alone.
+8. Repeat the same compact validation for every recorded input. Query raw input
+   series only when needed to explain an aggregation, gap, or mismatch; prefer
+   counts and grouped summaries over an unfiltered matrix.
+9. Report the dependency chain first, then a compact table of rule health and
+   per-level mismatch, missing-series, label, and lag results. Include exact
+   queries for reproducibility, but summarize samples instead of listing them.
+
+For a mature two-rule chain, the normal target is about 7-10 backend calls:
+three producer lookups, one combined instant summary, one combined range
+comparison per recorded level, and one combined freshness check. Exceed this
+when a nonzero check, rejected combined query, or genuine ambiguity requires
+drill-down, not merely to restate already established facts.
+
+Use this evidence ledger for a healthy mature two-rule chain; each slot may be
+filled at most once:
+
+1. Three exact producer lookups, including the terminal candidate.
+2. Two combined mismatch range queries, one per recorded level.
+3. At most two endpoint summaries: one for raw/expression labels and values and
+   one for stored recording values. Prefer one combined aggregate summary when
+   it answers both.
+4. One combined freshness query for every level.
+5. One combined range-statistics query only when the endpoint summaries do not
+   establish the requested values across the window.
+
+This gives 7-9 calls in the normal case. After a successful zero-mismatch result,
+do not add alternative union syntax, individual stored or expression queries,
+change-count probes, or another freshness form. Those calls are justified only
+by a rejected query, a missing expected source label, or a nonzero mismatch.
+
+## Dashboard Shows No Data
+
+1. Search once with the exact supplied dashboard title. After a match, use its
+   UID and do not try title variants unless the result is genuinely ambiguous.
+2. Read the dashboard summary, target panel query, templating values, and time
+   settings with the narrowest available calls. Treat these reads as a fixed
+   evidence ledger: one summary read, one panel-query read, one templating read,
+   and a time-property read only when the summary or query response lacks the
+   window. Reuse fields already returned. When the panel-query tool identifies
+   the panel and target, do not also read `$.panels[*]`, `$.panels[0]`, or the
+   full dashboard.
+3. Resolve the panel's datasource variable and identify its UID, type, and
+   backend before using a direct backend MCP. Choose one identity path: reuse a
+   datasource-list result when it contains the needed name, UID, type, and URL,
+   otherwise use one datasource-detail call. Do not call both merely to restate
+   identity, and never reread datasource details after executing the panel.
+   Check health once.
+4. Substitute the saved variable values without changing them and execute the
+   effective panel expression as one range query over the dashboard window. For
+   simple string variables, substitute locally from the templating read; do not
+   call the panel-query tool again only to resolve them. If Grafana-side variable
+   interpolation is necessary, make the resolved panel-query call the single
+   panel-query read for the investigation. The final range point also establishes
+   current absence, so do not repeat it as an instant query unless the range
+   response omits the endpoint or is ambiguous.
+5. Diagnose metric and selector availability with one compact backend query when
+   MetricsQL is available. Combine a zero-explicit count for the selected
+   expression with counts grouped by the suspected label, for example:
+
+   ```promql
+   label_set(
+     (count(<resolved_panel_expression>) or vector(0)),
+     "check", "selected_series"
+   )
+   or label_set(
+     count by (<suspected_label>) (<referenced_metric>),
+     "check", "available_label_value"
+   )
+   ```
+
+   This single result establishes whether the metric exists, whether the saved
+   selector matches, and which label values are present. If the backend lacks
+   this syntax, use at most one compact metric count and one scoped label-values
+   lookup. Do not additionally fetch the raw metric vector or perform metric-name
+   discovery after these results establish existence.
+6. Stop when the datasource is healthy, the resolved panel range is empty, the
+   referenced metric exists, and the selected label value is absent. These facts
+   are sufficient to attribute No data to selector or variable resolution; a
+   second reproduction through another interface and a control range for a
+   known-good label merely restate the conclusion.
+7. Drill down only if those facts conflict or remain ambiguous. Remove selectors
+   one at a time, preserving the same time window, and query one representative
+   series rather than widening to an unfiltered matrix.
+8. Report the dashboard and panel identifiers, datasource, stored and resolved
+   expressions, time window, decisive evidence, root-cause category, smallest
+   read-only correction, and at least one explicit limitation on the scope of
+   the conclusion.
+
+For a straightforward invalid-selector case, target 8-10 monitoring MCP calls:
+dashboard discovery and targeted properties, one datasource identity/health
+check, one panel range reproduction, and one compact backend diagnosis. Exceed
+this only for a tool error, ambiguous discovery, or conflicting evidence.
+
+## Noisy or Expensive Query
+
+1. Capture the exact expression, caller or panel, time range, step, and scope.
+2. Choose one bounded diagnostic appropriate to the question: active queries,
+   top queries, metric usage, or TSDB cardinality.
+3. Use the stored expression and that diagnostic to identify which selector,
+   grouping, or join expands the work. Evaluate a safe subexpression only when
+   those facts leave the cause ambiguous.
+4. Preserve semantics when proposing narrower selectors, earlier aggregation,
+   or a recording rule.
+5. Recommend a recording rule only when MCP evidence shows that the corrected
+   aggregation is reused or remains expensive; otherwise prefer the narrower
+   query itself.
+
+For a dashboard-backed expensive-query investigation, use this fixed normal
+ledger and stop when it is filled:
+
+1. Grafana, at most six calls: exact dashboard search; one panel-query read; at
+   most one numeric-ID or index-based panel property for execution settings;
+   one templating read; one time-property read; and one datasource-detail read.
+   Skip any slot whose fact is already returned. Do not add dashboard summary,
+   full-dashboard, title-filter property, datasource-list, or datasource-health
+   calls to the normal path.
+2. Backend diagnostic, exactly one family: choose recent top queries, current
+   active queries, one metric-usage view, or one current TSDB-cardinality view.
+   The word "or" is exclusive here. Do not combine these families or retry the
+   same family with alternative dates, matches, focus labels, or limits after a
+   successful response. An absent query in bounded retention is not proof that
+   it never ran.
+3. Candidate validation, at most one call: execute one safe narrow replacement.
+   For a current-state intent, omit `time` when the tool defaults to now. Do not
+   test it at midnight, the saved range start, or another control time, and do
+   not run multiple replacement variants.
+4. Estimate range cost from the stored selector, grouping, window, step, and the
+   single bounded diagnostic. Stop after these facts explain the risk and the
+   candidate answers the stated intent.
+
+This is an eight-call normal path with one spare recovery slot. Do not call
+documentation, metric metadata, datasource health, a query explainer, or the
+unsafe original unless a concrete error or unresolved backend-specific semantic
+question makes that exact call necessary. If a successful result is merely less
+detailed than hoped, report the limitation instead of widening the inventory.


### PR DESCRIPTION
# What does this PR do?

Adds the `metric-monitoring-via-mcp` LLM skill for read-only investigation of Grafana and VictoriaMetrics through connected MCP servers. It includes investigation playbooks, eval scenarios, and deterministic fixtures covering metric-backed dashboards, metrics, scrape discovery, alerts, and recording rules.

## Why

Agents need a consistent, evidence-based workflow for investigating live metric monitoring while staying within the available MCP capabilities. The skill prevents unsupported fallbacks such as `kubectl`, handles partial MCP access safely, and clearly separates metric monitoring from logs and traces.

Closes #329 

## Checklist

- [x] `make generate` re-run if `api/v1/*.go` changed — not required; no API files changed
- [x] `make test` passes — not required; no Go code changed
- [x] Docs / CRDs updated if user-facing — no CRD changes; skill documentation, playbooks, evals, and fixtures are included
