### PR TITLE
fix: Update profanity filter version and add excluded words

### DIFF
--- a/.github/workflows/profanity-filter.yaml
+++ b/.github/workflows/profanity-filter.yaml
@@ -20,10 +20,11 @@ jobs:
     - name: Scan issue or pull request for profanity
       # Conditionally run the step if the actor isn't a bot
       if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
-      uses: IEvangelist/profanity-filter@4655e7a15cd4a13a5c9b13affed04a487f556083 # 13.4.0
+      uses: IEvangelist/profanity-filter@96fb7c017b3219ea65c6a7ca70e5aed3ce5b4d7d # 13.4.6.2
       id: profanity-filter
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         # See https://bit.ly/potty-mouth-replacement-strategies
         replacement-strategy: middle-asterisk # See Replacement strategy
         custom-profane-words-url: https://github.com/Hesham-Elbadawi/list-of-banned-words/raw/refs/heads/master/ru
+        exclude-profane-words: mongo,robot


### PR DESCRIPTION
# What does this PR do?

Updates the profanity-filter GitHub workflow to a newer pinned action revision and adds allowed words exclusions (`mongo`, `robot`) to reduce false positives in issue/PR scanning.

## Why

The current profanity check can produce noisy failures on repository-specific terms.  
This change keeps moderation enabled while making the signal more accurate and reduces unnecessary CI friction.

## Checklist

- [x] `make generate` re-run if `api/v1/*.go` changed (not applicable: API files were not changed)
- [ ] `make test` passes
- [x] Docs / CRDs updated if user-facing (not applicable: workflow-only change)