### PR TITLE
fix: increased maxLabelsPerTimeseries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,6 @@ repos:
     rev: v0.9.0
     hooks:
       - id: pre-commit-update
-        args:
-          - --bleeding-edge
-          - pre-commit-golang
   - repo: https://github.com/pre-commit/pre-commit-hooks # General checks
     rev: v6.0.0
     hooks:
@@ -50,6 +47,6 @@ repos:
           - --config-file
           - .github/linters/.yaml-lint.yml
   - repo: https://github.com/exadmin/CyberFerret # CyberFerret Check
-    rev: v.1.2.5
+    rev: cfcli-v2.0.5
     hooks:
       - id: cyberferret

--- a/charts/qubership-monitoring-operator/Chart.yaml
+++ b/charts/qubership-monitoring-operator/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.28
+version: 1.4.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/values.schema.json
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/values.schema.json
@@ -1709,7 +1709,7 @@
                     "properties": {
                         "maxLabelsPerTimeseries": {
                             "type": "string",
-                            "default": "40"
+                            "default": "60"
                         }
                     },
                     "description": "Additional vmSingle container arguments.\nType: map[string]string\nMandatory: no\nDefault: {}"

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/values.schema.json
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/values.schema.json
@@ -451,7 +451,7 @@
                             "description": "Limits describes the maximum amount of compute resources allowed.\nType: object\nMandatory: no",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"  
+                                    "type": "string"
                                 },
                                 "memory": {
                                     "type": "string"
@@ -463,7 +463,7 @@
                             "description": "Requests describes the minimum amount of compute resources required.\nType: object\nMandatory: no",
                             "properties": {
                                 "cpu": {
-                                    "type": "string"  
+                                    "type": "string"
                                 },
                                 "memory": {
                                     "type": "string"
@@ -1076,7 +1076,7 @@
                                     "description": "Limits describes the maximum amount of compute resources allowed.\nType: object\nMandatory: no",
                                     "properties": {
                                         "cpu": {
-                                            "type": "string"  
+                                            "type": "string"
                                         },
                                         "memory": {
                                             "type": "string"
@@ -1088,7 +1088,7 @@
                                     "description": "Requests describes the minimum amount of compute resources required.\nType: object\nMandatory: no",
                                     "properties": {
                                         "cpu": {
-                                            "type": "string"  
+                                            "type": "string"
                                         },
                                         "memory": {
                                             "type": "string"
@@ -1224,7 +1224,7 @@
                                     "description": "Limits describes the maximum amount of compute resources allowed.\nType: object\nMandatory: no",
                                     "properties": {
                                         "cpu": {
-                                            "type": "string"  
+                                            "type": "string"
                                         },
                                         "memory": {
                                             "type": "string"
@@ -1236,7 +1236,7 @@
                                     "description": "Requests describes the minimum amount of compute resources required.\nType: object\nMandatory: no",
                                     "properties": {
                                         "cpu": {
-                                            "type": "string"  
+                                            "type": "string"
                                         },
                                         "memory": {
                                             "type": "string"
@@ -1399,7 +1399,7 @@
                                     "description": "Limits describes the maximum amount of compute resources allowed.\nType: object\nMandatory: no",
                                     "properties": {
                                         "cpu": {
-                                            "type": "string"  
+                                            "type": "string"
                                         },
                                         "memory": {
                                             "type": "string"
@@ -1411,7 +1411,7 @@
                                     "description": "Requests describes the minimum amount of compute resources required.\nType: object\nMandatory: no",
                                     "properties": {
                                         "cpu": {
-                                            "type": "string"  
+                                            "type": "string"
                                         },
                                         "memory": {
                                             "type": "string"
@@ -1554,7 +1554,7 @@
                             "properties": {
                                 "cpu": {
                                     "type": "string",
-                                    "default": "400m"   
+                                    "default": "400m"
                                 },
                                 "memory": {
                                     "type": "string",
@@ -1568,7 +1568,7 @@
                             "properties": {
                                 "cpu": {
                                     "type": "string",
-                                    "default": "200m"   
+                                    "default": "200m"
                                 },
                                 "memory": {
                                     "type": "string",
@@ -1769,7 +1769,7 @@
                             "properties": {
                                 "cpu": {
                                     "type": "string",
-                                    "default": "1000m"   
+                                    "default": "1000m"
                                 },
                                 "memory": {
                                     "type": "string",
@@ -1783,7 +1783,7 @@
                             "properties": {
                                 "cpu": {
                                     "type": "string",
-                                    "default": "500m"   
+                                    "default": "500m"
                                 },
                                 "memory": {
                                     "type": "string",

--- a/charts/qubership-monitoring-operator/charts/victoriametrics-operator/values.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics-operator/values.yaml
@@ -511,7 +511,7 @@ vmSingle:
   # Default: {}
   #
   extraArgs:
-    maxLabelsPerTimeseries: "40"
+    maxLabelsPerTimeseries: "60"
 
   # Allows set extra system environment variables for vmSingle.
   # Type: list[object]


### PR DESCRIPTION
# What does this PR do?

increasing value of maxLabelsPerTimeseries for vmSingle
'When limit is exceeded - extra labels are dropped, which could result in unexpected identical time series.'




