### PR TITLE
fix(grafana): disable automatic internet checks

### DIFF
--- a/.github/workflows/chart-test-linter.yaml
+++ b/.github/workflows/chart-test-linter.yaml
@@ -21,6 +21,7 @@ on:
       - 'charts/**'
       - 'docs/examples/deploy-parameters/**'
       - 'tools/crd-update/**'
+      - 'tools/verify-grafana-offline-settings.sh'
       - 'tools/verify-helm-crds.sh'
       - 'tools/verify-subchart-paths.sh'
       - 'Makefile'
@@ -38,6 +39,7 @@ on:
       - 'charts/**'
       - 'docs/examples/deploy-parameters/**'
       - 'tools/crd-update/**'
+      - 'tools/verify-grafana-offline-settings.sh'
       - 'tools/verify-helm-crds.sh'
       - 'tools/verify-subchart-paths.sh'
       - 'Makefile'
@@ -81,6 +83,9 @@ jobs:
 
       - name: Verify subchart paths
         run: tools/verify-subchart-paths.sh
+
+      - name: Verify Grafana offline settings
+        run: tools/verify-grafana-offline-settings.sh
 
       - name: Copy examples for ct in /charts/qubership-monitoring-operator/ci/
         run: |

--- a/charts/qubership-monitoring-operator/charts/grafana/templates/configmap-extra-vars.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana/templates/configmap-extra-vars.yaml
@@ -4,7 +4,7 @@ metadata:
   name: grafana-extra-vars
   labels:
     {{- include "monitoring.labels" (dict "ctx" . "name" "grafana-extra-vars") | nindent 4 }}
-{{- $requiredOfflineSettings := dict
+{{- $offlineDefaults := dict
   "GF_PLUGINS_PREINSTALL_DISABLED" true
   "GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED" true
   "GF_ANALYTICS_CHECK_FOR_UPDATES" false
@@ -12,7 +12,40 @@ metadata:
   "GF_ANALYTICS_REPORTING_ENABLED" false
   "GF_NEWS_NEWS_FEED_ENABLED" false
 -}}
-{{- $extraVars := mergeOverwrite (deepCopy (.Values.extraVars | default dict)) $requiredOfflineSettings }}
+{{- $userExtraVars := deepCopy (.Values.extraVars | default dict) }}
+{{- $secretExtraVars := .Values.extraVarsSecret | default dict }}
+{{- $effectivePreinstall := get $userExtraVars "GF_PLUGINS_PREINSTALL" }}
+{{- if hasKey $secretExtraVars "GF_PLUGINS_PREINSTALL" }}
+  {{- $effectivePreinstall = get $secretExtraVars "GF_PLUGINS_PREINSTALL" }}
+{{- end }}
+{{- $effectivePreinstallSync := get $userExtraVars "GF_PLUGINS_PREINSTALL_SYNC" }}
+{{- if hasKey $secretExtraVars "GF_PLUGINS_PREINSTALL_SYNC" }}
+  {{- $effectivePreinstallSync = get $secretExtraVars "GF_PLUGINS_PREINSTALL_SYNC" }}
+{{- end }}
+{{- $preinstallCandidates := list $effectivePreinstall $effectivePreinstallSync }}
+{{- $hasCustomPreinstall := false }}
+{{- range $candidate := $preinstallCandidates }}
+  {{- if ne (trim (toString $candidate)) "" }}
+    {{- $hasCustomPreinstall = true }}
+  {{- end }}
+{{- end }}
+{{- $preinstallDisabledIsExplicit := false }}
+{{- $preinstallDisabled := false }}
+{{- if hasKey $userExtraVars "GF_PLUGINS_PREINSTALL_DISABLED" }}
+  {{- $preinstallDisabledIsExplicit = true }}
+  {{- $preinstallDisabled = eq (lower (toString (get $userExtraVars "GF_PLUGINS_PREINSTALL_DISABLED"))) "true" }}
+{{- end }}
+{{- if hasKey $secretExtraVars "GF_PLUGINS_PREINSTALL_DISABLED" }}
+  {{- $preinstallDisabledIsExplicit = true }}
+  {{- $preinstallDisabled = eq (lower (toString (get $secretExtraVars "GF_PLUGINS_PREINSTALL_DISABLED"))) "true" }}
+{{- end }}
+{{- if and $hasCustomPreinstall $preinstallDisabledIsExplicit $preinstallDisabled }}
+  {{- fail "GF_PLUGINS_PREINSTALL_DISABLED=true conflicts with GF_PLUGINS_PREINSTALL or GF_PLUGINS_PREINSTALL_SYNC" }}
+{{- end }}
+{{- $extraVars := mergeOverwrite (deepCopy $offlineDefaults) $userExtraVars }}
+{{- if $hasCustomPreinstall }}
+  {{- $_ := set $extraVars "GF_PLUGINS_PREINSTALL_DISABLED" false }}
+{{- end }}
 {{- if .Values.imageRenderer.install }}
   {{- if not (get $extraVars "GF_RENDERING_SERVER_URL") }}
     {{- $_ := set $extraVars "GF_RENDERING_SERVER_URL" "http://grafana-image-renderer:8081/render" }}

--- a/charts/qubership-monitoring-operator/charts/grafana/templates/configmap-extra-vars.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana/templates/configmap-extra-vars.yaml
@@ -4,20 +4,24 @@ metadata:
   name: grafana-extra-vars
   labels:
     {{- include "monitoring.labels" (dict "ctx" . "name" "grafana-extra-vars") | nindent 4 }}
-{{- if .Values.extraVars }}
-data:
-  {{- range $key, $val := .Values.extraVars }}
-  {{ $key | quote | indent 4}}: {{ $val | quote }}
-  {{- end}}
-  {{- if .Values.imageRenderer.install }}
-    {{- if not .Values.extraVars.GF_RENDERING_SERVER_URL }}
-      "GF_RENDERING_SERVER_URL": "http://grafana-image-renderer:8081/render"
-    {{- end }}
-    {{- if not .Values.extraVars.GF_RENDERING_CALLBACK_URL }}
-      "GF_RENDERING_CALLBACK_URL": "http://grafana-service:3000/"
-    {{- end }}
+{{- $requiredOfflineSettings := dict
+  "GF_PLUGINS_PREINSTALL_DISABLED" true
+  "GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED" true
+  "GF_ANALYTICS_CHECK_FOR_UPDATES" false
+  "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES" false
+  "GF_ANALYTICS_REPORTING_ENABLED" false
+  "GF_NEWS_NEWS_FEED_ENABLED" false
+-}}
+{{- $extraVars := mergeOverwrite (deepCopy (.Values.extraVars | default dict)) $requiredOfflineSettings }}
+{{- if .Values.imageRenderer.install }}
+  {{- if not (get $extraVars "GF_RENDERING_SERVER_URL") }}
+    {{- $_ := set $extraVars "GF_RENDERING_SERVER_URL" "http://grafana-image-renderer:8081/render" }}
   {{- end }}
-{{- else }}
-data:
+  {{- if not (get $extraVars "GF_RENDERING_CALLBACK_URL") }}
+    {{- $_ := set $extraVars "GF_RENDERING_CALLBACK_URL" "http://grafana-service:3000/" }}
+  {{- end }}
 {{- end }}
-
+data:
+  {{- range $key, $val := $extraVars }}
+  {{ $key | quote | indent 4}}: {{ $val | quote }}
+  {{- end }}

--- a/charts/qubership-monitoring-operator/charts/grafana/values.schema.json
+++ b/charts/qubership-monitoring-operator/charts/grafana/values.schema.json
@@ -149,10 +149,20 @@
             "type": "object",
             "description": "Allows set extra system environment variables for grafana. The properties used to override values from grafana.ini. Ref: https://grafana.com/docs/grafana/latest/administration/configuration/#configure-with-environment-variables",
             "properties": {
+                "GF_ANALYTICS_CHECK_FOR_UPDATES": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disable Grafana update checks"
+                },
                 "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable plugin update checks for Grafana analytics"
+                    "description": "Disable automatic plugin update checks"
+                },
+                "GF_ANALYTICS_REPORTING_ENABLED": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disable anonymous usage reporting"
                 },
                 "GF_AUTH_ANONYMOUS_HIDE_VERSION": {
                     "type": "boolean",
@@ -173,6 +183,21 @@
                     "type": "string",
                     "default": "*",
                     "description": "Allowed origins for Grafana live streaming"
+                },
+                "GF_NEWS_NEWS_FEED_ENABLED": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disable the Grafana news feed"
+                },
+                "GF_PLUGINS_PREINSTALL_DISABLED": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Disable automatic plugin preinstallation"
+                },
+                "GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Disable automatic plugin public key retrieval"
                 },
                 "GF_SECURITY_ANGULAR_SUPPORT_ENABLED": {
                     "type": "boolean",

--- a/charts/qubership-monitoring-operator/charts/grafana/values.schema.json
+++ b/charts/qubership-monitoring-operator/charts/grafana/values.schema.json
@@ -192,7 +192,15 @@
                 "GF_PLUGINS_PREINSTALL_DISABLED": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Disable automatic plugin preinstallation"
+                    "description": "Disable automatic plugin preinstallation when no custom preinstall list is configured"
+                },
+                "GF_PLUGINS_PREINSTALL": {
+                    "type": "string",
+                    "description": "Comma-separated plugins to install asynchronously, optionally with pinned versions and custom URLs"
+                },
+                "GF_PLUGINS_PREINSTALL_SYNC": {
+                    "type": "string",
+                    "description": "Comma-separated plugins to install synchronously, optionally with pinned versions and custom URLs"
                 },
                 "GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED": {
                     "type": "boolean",

--- a/charts/qubership-monitoring-operator/charts/grafana/values.schema.json
+++ b/charts/qubership-monitoring-operator/charts/grafana/values.schema.json
@@ -147,97 +147,26 @@
         },
         "extraVars": {
             "type": "object",
-            "description": "Allows set extra system environment variables for grafana. The properties used to override values from grafana.ini. Ref: https://grafana.com/docs/grafana/latest/administration/configuration/#configure-with-environment-variables",
-            "properties": {
-                "GF_ANALYTICS_CHECK_FOR_UPDATES": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Disable Grafana update checks"
-                },
-                "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Disable automatic plugin update checks"
-                },
-                "GF_ANALYTICS_REPORTING_ENABLED": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Disable anonymous usage reporting"
-                },
-                "GF_AUTH_ANONYMOUS_HIDE_VERSION": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Hide Grafana version when anonymous access is enabled"
-                },
-                "GF_AUTH_LOGIN_COOKIE_NAME": {
-                    "type": "string",
-                    "default": "__Host-grafana_session",
-                    "description": "Name of the Grafana login cookie"
-                },
-                "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH": {
-                    "type": "string",
-                    "default": "/etc/grafana-configmaps/grafana-home-dashboard/grafana-home-dashboard.json",
-                    "description": "Path to the default Grafana home dashboard file"
-                },
-                "GF_LIVE_ALLOWED_ORIGINS": {
-                    "type": "string",
-                    "default": "*",
-                    "description": "Allowed origins for Grafana live streaming"
-                },
-                "GF_NEWS_NEWS_FEED_ENABLED": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Disable the Grafana news feed"
-                },
-                "GF_PLUGINS_PREINSTALL_DISABLED": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Disable automatic plugin preinstallation when no custom preinstall list is configured"
-                },
-                "GF_PLUGINS_PREINSTALL": {
-                    "type": "string",
-                    "description": "Comma-separated plugins to install asynchronously, optionally with pinned versions and custom URLs"
-                },
-                "GF_PLUGINS_PREINSTALL_SYNC": {
-                    "type": "string",
-                    "description": "Comma-separated plugins to install synchronously, optionally with pinned versions and custom URLs"
-                },
-                "GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Disable automatic plugin public key retrieval"
-                },
-                "GF_SECURITY_ANGULAR_SUPPORT_ENABLED": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enable Angular support security settings in Grafana"
-                },
-                "GF_SECURITY_CONTENT_SECURITY_POLICY": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enable Grafana content security policy"
-                },
-                "GF_SECURITY_COOKIE_SAMESITE": {
-                    "type": "string",
-                    "default": "strict",
-                    "description": "SameSite setting for Grafana cookies"
-                },
-                "GF_SECURITY_COOKIE_SECURE": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Require secure Grafana cookies"
-                },
-                "GF_SERVER_ENFORCE_DOMAIN": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enforce Grafana server domain"
-                }
+            "description": "Additional Grafana environment variables. Values override matching settings from grafana.ini. Ref: https://grafana.com/docs/grafana/latest/administration/configuration/#configure-with-environment-variables",
+            "additionalProperties": {
+                "type": [
+                    "string",
+                    "number",
+                    "boolean"
+                ]
             }
         },
         "extraVarsSecret": {
             "type": "object",
-            "description": "Allows set extra system environment variables for Grafana like an extraVars, but set variables into the Secret instead of ConfigMap. If extraVars and ExtraVarsSecret have variables with equals keys, value will be taken from the Secret",
-            "default": {}
+            "description": "Additional Grafana environment variables stored in a Secret. Values override duplicate keys from extraVars.",
+            "default": {},
+            "additionalProperties": {
+                "type": [
+                    "string",
+                    "number",
+                    "boolean"
+                ]
+            }
         },
         "grafanaHomeDashboard": {
             "type": "boolean",

--- a/charts/qubership-monitoring-operator/charts/grafana/values.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana/values.yaml
@@ -241,7 +241,9 @@ disableDefaultAdminSecret: false
 #   size: 2Gi               # Requested size, e.g. `10Gi`
 #   class: local-storage    # Storage class name
 
-# Allows set extra system environment variables for grafana. The properties used to override values from grafana.ini.
+# Allows set extra system environment variables for Grafana. The properties are used to override values from grafana.ini.
+# The six offline settings below are enforced by the chart and cannot be overridden through extraVars or
+# extraVarsSecret.
 # Ref: https://grafana.com/docs/grafana/latest/administration/configuration/#configure-with-environment-variables
 # Type: object
 # Mandatory: no
@@ -249,7 +251,12 @@ disableDefaultAdminSecret: false
 extraVars:
   GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana-configmaps/grafana-home-dashboard/grafana-home-dashboard.json
   GF_LIVE_ALLOWED_ORIGINS: "*"
+  GF_PLUGINS_PREINSTALL_DISABLED: true
+  GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED: true
+  GF_ANALYTICS_CHECK_FOR_UPDATES: false
   GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES: false
+  GF_ANALYTICS_REPORTING_ENABLED: false
+  GF_NEWS_NEWS_FEED_ENABLED: false
   GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
   GF_SECURITY_CONTENT_SECURITY_POLICY: true
   GF_SECURITY_COOKIE_SECURE: true
@@ -265,7 +272,8 @@ extraVars:
 
 # Allows set extra system environment variables for Grafana like an extraVars,
 # but set variables into the Secret instead of ConfigMap.
-# If extraVars and ExtraVarsSecret have variables with equals keys, value will be taken from the Secret.
+# If extraVars and extraVarsSecret have equal keys, the value is taken from the Secret, except for the enforced offline
+# settings listed in extraVars.
 # Type: object
 # Mandatory: no
 # Default: {}

--- a/charts/qubership-monitoring-operator/charts/grafana/values.yaml
+++ b/charts/qubership-monitoring-operator/charts/grafana/values.yaml
@@ -242,8 +242,9 @@ disableDefaultAdminSecret: false
 #   class: local-storage    # Storage class name
 
 # Allows set extra system environment variables for Grafana. The properties are used to override values from grafana.ini.
-# The six offline settings below are enforced by the chart and cannot be overridden through extraVars or
-# extraVarsSecret.
+# The chart supplies offline defaults when these maps do not override them. A custom GF_PLUGINS_PREINSTALL or
+# GF_PLUGINS_PREINSTALL_SYNC value enables plugin preinstallation unless GF_PLUGINS_PREINSTALL_DISABLED is explicitly
+# true, which is rejected as a conflicting configuration.
 # Ref: https://grafana.com/docs/grafana/latest/administration/configuration/#configure-with-environment-variables
 # Type: object
 # Mandatory: no
@@ -251,12 +252,6 @@ disableDefaultAdminSecret: false
 extraVars:
   GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana-configmaps/grafana-home-dashboard/grafana-home-dashboard.json
   GF_LIVE_ALLOWED_ORIGINS: "*"
-  GF_PLUGINS_PREINSTALL_DISABLED: true
-  GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED: true
-  GF_ANALYTICS_CHECK_FOR_UPDATES: false
-  GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES: false
-  GF_ANALYTICS_REPORTING_ENABLED: false
-  GF_NEWS_NEWS_FEED_ENABLED: false
   GF_SECURITY_ANGULAR_SUPPORT_ENABLED: true
   GF_SECURITY_CONTENT_SECURITY_POLICY: true
   GF_SECURITY_COOKIE_SECURE: true
@@ -272,8 +267,7 @@ extraVars:
 
 # Allows set extra system environment variables for Grafana like an extraVars,
 # but set variables into the Secret instead of ConfigMap.
-# If extraVars and extraVarsSecret have equal keys, the value is taken from the Secret, except for the enforced offline
-# settings listed in extraVars.
+# If extraVars and extraVarsSecret have equal keys, the value is taken from the Secret.
 # Type: object
 # Mandatory: no
 # Default: {}

--- a/charts/qubership-monitoring-operator/templates/oauth2-configs/secret-extra-vars-grafana.yaml
+++ b/charts/qubership-monitoring-operator/templates/oauth2-configs/secret-extra-vars-grafana.yaml
@@ -17,18 +17,8 @@ stringData:
 {{- end}}
 {{- end}}
 {{- if .Values.grafana.extraVarsSecret }}
-  {{- $reservedOfflineSettings := dict
-    "GF_PLUGINS_PREINSTALL_DISABLED" true
-    "GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED" true
-    "GF_ANALYTICS_CHECK_FOR_UPDATES" true
-    "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES" true
-    "GF_ANALYTICS_REPORTING_ENABLED" true
-    "GF_NEWS_NEWS_FEED_ENABLED" true
-  }}
   {{- range $key, $val := .Values.grafana.extraVarsSecret }}
-  {{- if not (hasKey $reservedOfflineSettings $key) }}
   {{ $key | quote | indent 6}}: {{ $val | quote }}
-  {{- end }}
 {{- end}}
 {{- end}}
 {{- end}}

--- a/charts/qubership-monitoring-operator/templates/oauth2-configs/secret-extra-vars-grafana.yaml
+++ b/charts/qubership-monitoring-operator/templates/oauth2-configs/secret-extra-vars-grafana.yaml
@@ -17,8 +17,18 @@ stringData:
 {{- end}}
 {{- end}}
 {{- if .Values.grafana.extraVarsSecret }}
+  {{- $reservedOfflineSettings := dict
+    "GF_PLUGINS_PREINSTALL_DISABLED" true
+    "GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED" true
+    "GF_ANALYTICS_CHECK_FOR_UPDATES" true
+    "GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES" true
+    "GF_ANALYTICS_REPORTING_ENABLED" true
+    "GF_NEWS_NEWS_FEED_ENABLED" true
+  }}
   {{- range $key, $val := .Values.grafana.extraVarsSecret }}
+  {{- if not (hasKey $reservedOfflineSettings $key) }}
   {{ $key | quote | indent 6}}: {{ $val | quote }}
+  {{- end }}
 {{- end}}
 {{- end}}
 {{- end}}

--- a/controllers/grafana/grafana_test.go
+++ b/controllers/grafana/grafana_test.go
@@ -164,7 +164,9 @@ func TestGrafanaPodTemplateAnnotationsHandlesMissingTemplate(t *testing.T) {
 		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
 	})
 	assert.NoError(t, err)
-	assert.NotNil(t, grafanaPodTemplateAnnotations(manifest))
+	assert.Nil(t, grafanaPodTemplateAnnotations(manifest))
+	manifest.Spec.Deployment.Spec.Template.Annotations = map[string]string{"custom": "value"}
+	assert.Equal(t, map[string]string{"custom": "value"}, grafanaPodTemplateAnnotations(manifest))
 }
 
 func TestHandleGrafanaCreatesResourceWithoutExtraVarsResources(t *testing.T) {

--- a/controllers/grafana/grafana_test.go
+++ b/controllers/grafana/grafana_test.go
@@ -10,6 +10,7 @@ import (
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils/labelsassert"
+	"github.com/go-logr/logr"
 	grafv1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,8 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -98,6 +101,55 @@ func TestAddGrafanaExtraVarsResourceVersionsPreservesVersionForMissingResource(t
 		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsSecretResourceVersionAnnotation])
 }
 
+func TestAddGrafanaExtraVarsResourceVersionsPreservesMissingConfigMapVersion(t *testing.T) {
+	manifest, err := grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	})
+	assert.NoError(t, err)
+
+	reconciler := &GrafanaReconciler{KubeClient: kubernetesfake.NewSimpleClientset(
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "grafana-extra-vars-secret", Namespace: "monitoring", ResourceVersion: "new-secret-version",
+		}},
+	)}
+	existingAnnotations := map[string]string{
+		grafanaExtraVarsConfigMapResourceVersionAnnotation: "old-config-version",
+	}
+
+	err = reconciler.addGrafanaExtraVarsResourceVersions(
+		context.Background(), "monitoring", manifest, existingAnnotations)
+	assert.NoError(t, err)
+	assert.Equal(t, "old-config-version",
+		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation])
+	assert.Equal(t, "new-secret-version",
+		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsSecretResourceVersionAnnotation])
+}
+
+func TestAddGrafanaExtraVarsResourceVersionsInitializesAnnotations(t *testing.T) {
+	manifest, err := grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	})
+	assert.NoError(t, err)
+	manifest.Spec.Deployment.Spec.Template.Annotations = nil
+	reconciler := &GrafanaReconciler{KubeClient: kubernetesfake.NewSimpleClientset(
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: "grafana-extra-vars", Namespace: "monitoring", ResourceVersion: "config-version",
+		}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "grafana-extra-vars-secret", Namespace: "monitoring", ResourceVersion: "secret-version",
+		}},
+	)}
+
+	err = reconciler.addGrafanaExtraVarsResourceVersions(context.Background(), "monitoring", manifest, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "config-version",
+		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation])
+	assert.Equal(t, "secret-version",
+		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsSecretResourceVersionAnnotation])
+}
+
 func TestGrafanaPodTemplateAnnotationsHandlesMissingTemplate(t *testing.T) {
 	manifest, err := grafana(&monv1.PlatformMonitoring{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
@@ -107,6 +159,108 @@ func TestGrafanaPodTemplateAnnotationsHandlesMissingTemplate(t *testing.T) {
 	manifest.Spec.Deployment.Spec.Template = nil
 
 	assert.Nil(t, grafanaPodTemplateAnnotations(manifest))
+	manifest, err = grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, grafanaPodTemplateAnnotations(manifest))
+}
+
+func TestHandleGrafanaCreatesResourceWithoutExtraVarsResources(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	assert.NoError(t, monv1.AddToScheme(testScheme))
+	assert.NoError(t, grafv1.AddToScheme(testScheme))
+	controllerClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+	reconciler := &GrafanaReconciler{
+		KubeClient: kubernetesfake.NewSimpleClientset(),
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: controllerClient,
+			Scheme: testScheme,
+			Log:    logr.Discard(),
+		},
+	}
+	platformMonitoring := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	}
+
+	err := reconciler.handleGrafana(platformMonitoring)
+	assert.NoError(t, err)
+
+	created := &grafv1.Grafana{}
+	err = controllerClient.Get(context.Background(), types.NamespacedName{
+		Name: "grafana", Namespace: "monitoring",
+	}, created)
+	assert.NoError(t, err)
+	assert.NotNil(t, created.Spec.Deployment)
+}
+
+func TestHandleGrafanaReturnsExtraVarsAPIErrorForExistingResource(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	assert.NoError(t, monv1.AddToScheme(testScheme))
+	assert.NoError(t, grafv1.AddToScheme(testScheme))
+	platformMonitoring := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	}
+	existing, err := grafana(platformMonitoring)
+	assert.NoError(t, err)
+	existing.Spec.Deployment.Spec.Template = nil
+	controllerClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(existing).Build()
+	kubeClient := kubernetesfake.NewSimpleClientset()
+	kubeClient.PrependReactor("get", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "configmaps"}, "grafana-extra-vars", assert.AnError)
+	})
+	reconciler := &GrafanaReconciler{
+		KubeClient: kubeClient,
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: controllerClient,
+			Scheme: testScheme,
+			Log:    logr.Discard(),
+		},
+	}
+
+	err = reconciler.handleGrafana(platformMonitoring)
+	assert.ErrorContains(t, err, "cannot get Grafana extra-vars ConfigMap")
+}
+
+func TestHandleGrafanaReturnsClientError(t *testing.T) {
+	reconciler := &GrafanaReconciler{
+		KubeClient: kubernetesfake.NewSimpleClientset(),
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+			Scheme: runtime.NewScheme(),
+			Log:    logr.Discard(),
+		},
+	}
+	platformMonitoring := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Name: "monitoring", Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	}
+
+	err := reconciler.handleGrafana(platformMonitoring)
+	assert.Error(t, err)
+}
+
+func TestAddGrafanaExtraVarsResourceVersionsReturnsSecretAPIError(t *testing.T) {
+	manifest, err := grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	})
+	assert.NoError(t, err)
+	kubeClient := kubernetesfake.NewSimpleClientset(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: "grafana-extra-vars", Namespace: "monitoring",
+	}})
+	kubeClient.PrependReactor("get", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "secrets"}, "grafana-extra-vars-secret", assert.AnError)
+	})
+	reconciler := &GrafanaReconciler{KubeClient: kubeClient}
+
+	err = reconciler.addGrafanaExtraVarsResourceVersions(context.Background(), "monitoring", manifest, nil)
+	assert.ErrorContains(t, err, "cannot get Grafana extra-vars Secret")
 }
 
 var (

--- a/controllers/grafana/grafana_test.go
+++ b/controllers/grafana/grafana_test.go
@@ -75,6 +75,21 @@ func TestAddGrafanaExtraVarsResourceVersionsWhenResourcesAreMissing(t *testing.T
 	assert.Equal(t, "retained", manifest.Spec.Deployment.Spec.Template.Annotations["example.com/user-annotation"])
 }
 
+func TestAddGrafanaExtraVarsResourceVersionsKeepsAnnotationsNilWhenResourcesAreMissing(t *testing.T) {
+	manifest, err := grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	})
+	require.NoError(t, err)
+	require.Nil(t, manifest.Spec.Deployment.Spec.Template.Annotations)
+	reconciler := &GrafanaReconciler{KubeClient: kubernetesfake.NewSimpleClientset()}
+
+	err = reconciler.addGrafanaExtraVarsResourceVersions(context.Background(), "monitoring", manifest, nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, manifest.Spec.Deployment.Spec.Template.Annotations)
+}
+
 func TestAddGrafanaExtraVarsResourceVersionsPreservesVersionForMissingResource(t *testing.T) {
 	manifest, err := grafana(&monv1.PlatformMonitoring{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},

--- a/controllers/grafana/grafana_test.go
+++ b/controllers/grafana/grafana_test.go
@@ -20,9 +20,37 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestAddGrafanaExtraVarsResourceVersions(t *testing.T) {
+	manifest, err := grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec: monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{
+			Annotations: map[string]string{"example.com/user-annotation": "retained"},
+		}},
+	})
+	assert.NoError(t, err)
+
+	reconciler := &GrafanaReconciler{KubeClient: kubernetesfake.NewSimpleClientset(
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: "grafana-extra-vars", Namespace: "monitoring", ResourceVersion: "config-version",
+		}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "grafana-extra-vars-secret", Namespace: "monitoring", ResourceVersion: "secret-version",
+		}},
+	)}
+
+	err = reconciler.addGrafanaExtraVarsResourceVersions(context.Background(), "monitoring", manifest)
+	assert.NoError(t, err)
+	assert.Equal(t, "config-version",
+		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation])
+	assert.Equal(t, "secret-version",
+		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsSecretResourceVersionAnnotation])
+	assert.Equal(t, "retained", manifest.Spec.Deployment.Spec.Template.Annotations["example.com/user-annotation"])
+}
 
 var (
 	cr              *monv1.PlatformMonitoring

--- a/controllers/grafana/grafana_test.go
+++ b/controllers/grafana/grafana_test.go
@@ -43,13 +43,70 @@ func TestAddGrafanaExtraVarsResourceVersions(t *testing.T) {
 		}},
 	)}
 
-	err = reconciler.addGrafanaExtraVarsResourceVersions(context.Background(), "monitoring", manifest)
+	err = reconciler.addGrafanaExtraVarsResourceVersions(context.Background(), "monitoring", manifest, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "config-version",
 		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation])
 	assert.Equal(t, "secret-version",
 		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsSecretResourceVersionAnnotation])
 	assert.Equal(t, "retained", manifest.Spec.Deployment.Spec.Template.Annotations["example.com/user-annotation"])
+}
+
+func TestAddGrafanaExtraVarsResourceVersionsWhenResourcesAreMissing(t *testing.T) {
+	manifest, err := grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec: monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{
+			Annotations: map[string]string{"example.com/user-annotation": "retained"},
+		}},
+	})
+	assert.NoError(t, err)
+
+	reconciler := &GrafanaReconciler{KubeClient: kubernetesfake.NewSimpleClientset()}
+
+	err = reconciler.addGrafanaExtraVarsResourceVersions(context.Background(), "monitoring", manifest, nil)
+	assert.NoError(t, err)
+	assert.NotContains(t, manifest.Spec.Deployment.Spec.Template.Annotations,
+		grafanaExtraVarsConfigMapResourceVersionAnnotation)
+	assert.NotContains(t, manifest.Spec.Deployment.Spec.Template.Annotations,
+		grafanaExtraVarsSecretResourceVersionAnnotation)
+	assert.Equal(t, "retained", manifest.Spec.Deployment.Spec.Template.Annotations["example.com/user-annotation"])
+}
+
+func TestAddGrafanaExtraVarsResourceVersionsPreservesVersionForMissingResource(t *testing.T) {
+	manifest, err := grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	})
+	assert.NoError(t, err)
+
+	reconciler := &GrafanaReconciler{KubeClient: kubernetesfake.NewSimpleClientset(
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: "grafana-extra-vars", Namespace: "monitoring", ResourceVersion: "new-config-version",
+		}},
+	)}
+	existingAnnotations := map[string]string{
+		grafanaExtraVarsConfigMapResourceVersionAnnotation: "old-config-version",
+		grafanaExtraVarsSecretResourceVersionAnnotation:    "old-secret-version",
+	}
+
+	err = reconciler.addGrafanaExtraVarsResourceVersions(
+		context.Background(), "monitoring", manifest, existingAnnotations)
+	assert.NoError(t, err)
+	assert.Equal(t, "new-config-version",
+		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation])
+	assert.Equal(t, "old-secret-version",
+		manifest.Spec.Deployment.Spec.Template.Annotations[grafanaExtraVarsSecretResourceVersionAnnotation])
+}
+
+func TestGrafanaPodTemplateAnnotationsHandlesMissingTemplate(t *testing.T) {
+	manifest, err := grafana(&monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+		Spec:       monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{}},
+	})
+	assert.NoError(t, err)
+	manifest.Spec.Deployment.Spec.Template = nil
+
+	assert.Nil(t, grafanaPodTemplateAnnotations(manifest))
 }
 
 var (

--- a/controllers/grafana/handlers.go
+++ b/controllers/grafana/handlers.go
@@ -31,27 +31,45 @@ const (
 	grafanaExtraVarsSecretResourceVersionAnnotation    = "monitoring.netcracker.com/grafana-extra-vars-secret-resource-version"
 )
 
+func grafanaPodTemplateAnnotations(manifest *grafv1.Grafana) map[string]string {
+	if manifest == nil || manifest.Spec.Deployment == nil || manifest.Spec.Deployment.Spec.Template == nil {
+		return nil
+	}
+	return manifest.Spec.Deployment.Spec.Template.Annotations
+}
+
 func (r *GrafanaReconciler) addGrafanaExtraVarsResourceVersions(
 	ctx context.Context,
 	namespace string,
 	manifest *grafv1.Grafana,
+	existingAnnotations map[string]string,
 ) error {
 	configMap, err := r.KubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, "grafana-extra-vars", metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("cannot get Grafana extra-vars ConfigMap: %w", err)
 	}
+	configMapFound := err == nil
 	secret, err := r.KubeClient.CoreV1().Secrets(namespace).Get(ctx, "grafana-extra-vars-secret", metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("cannot get Grafana extra-vars Secret: %w", err)
 	}
+	secretFound := err == nil
 
 	annotations := manifest.Spec.Deployment.Spec.Template.Annotations
 	if annotations == nil {
 		annotations = make(map[string]string)
 		manifest.Spec.Deployment.Spec.Template.Annotations = annotations
 	}
-	annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation] = configMap.ResourceVersion
-	annotations[grafanaExtraVarsSecretResourceVersionAnnotation] = secret.ResourceVersion
+	if configMapFound {
+		annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation] = configMap.ResourceVersion
+	} else if resourceVersion, ok := existingAnnotations[grafanaExtraVarsConfigMapResourceVersionAnnotation]; ok {
+		annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation] = resourceVersion
+	}
+	if secretFound {
+		annotations[grafanaExtraVarsSecretResourceVersionAnnotation] = secret.ResourceVersion
+	} else if resourceVersion, ok := existingAnnotations[grafanaExtraVarsSecretResourceVersionAnnotation]; ok {
+		annotations[grafanaExtraVarsSecretResourceVersionAnnotation] = resourceVersion
+	}
 	return nil
 }
 
@@ -61,24 +79,32 @@ func (r *GrafanaReconciler) handleGrafana(cr *monv1.PlatformMonitoring) error {
 		r.Log.Error(err, "Failed creating Grafana manifest")
 		return err
 	}
-	if err = r.addGrafanaExtraVarsResourceVersions(context.TODO(), m.GetNamespace(), m); err != nil {
-		r.Log.Error(err, "Failed adding Grafana extra-vars resource versions")
-		return err
-	}
-
 	// Note: Config.AuthGenericOauth access removed as Config is now runtime.RawExtension in grafana-operator v5
 	// OAuth configuration is handled in manifest.go during Grafana creation
 	// Explicit GVK ensures correct API group (grafana.integreatly.org/v1beta1) for v5
 	e := &grafv1.Grafana{ObjectMeta: m.ObjectMeta}
 	e.SetGroupVersionKind(schema.GroupVersionKind{Group: "grafana.integreatly.org", Version: "v1beta1", Kind: "Grafana"})
-	if err = r.GetResource(e); err != nil {
-		if errors.IsNotFound(err) {
-			if err = r.CreateResource(cr, m); err != nil {
-				return err
-			}
-			return r.migrateLegacyGrafanaResources(context.TODO(), cr, m)
-		}
+	err = r.GetResource(e)
+	grafanaExists := err == nil
+	if err != nil && !errors.IsNotFound(err) {
 		return err
+	}
+
+	var existingAnnotations map[string]string
+	if grafanaExists {
+		existingAnnotations = grafanaPodTemplateAnnotations(e)
+	}
+	if err = r.addGrafanaExtraVarsResourceVersions(
+		context.TODO(), m.GetNamespace(), m, existingAnnotations,
+	); err != nil {
+		r.Log.Error(err, "Failed adding Grafana extra-vars resource versions")
+		return err
+	}
+	if !grafanaExists {
+		if err = r.CreateResource(cr, m); err != nil {
+			return err
+		}
+		return r.migrateLegacyGrafanaResources(context.TODO(), cr, m)
 	}
 
 	if applyGrafanaDesiredState(e, m) {

--- a/controllers/grafana/handlers.go
+++ b/controllers/grafana/handlers.go
@@ -26,10 +26,43 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
+const (
+	grafanaExtraVarsConfigMapResourceVersionAnnotation = "monitoring.netcracker.com/grafana-extra-vars-configmap-resource-version"
+	grafanaExtraVarsSecretResourceVersionAnnotation    = "monitoring.netcracker.com/grafana-extra-vars-secret-resource-version"
+)
+
+func (r *GrafanaReconciler) addGrafanaExtraVarsResourceVersions(
+	ctx context.Context,
+	namespace string,
+	manifest *grafv1.Grafana,
+) error {
+	configMap, err := r.KubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, "grafana-extra-vars", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot get Grafana extra-vars ConfigMap: %w", err)
+	}
+	secret, err := r.KubeClient.CoreV1().Secrets(namespace).Get(ctx, "grafana-extra-vars-secret", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot get Grafana extra-vars Secret: %w", err)
+	}
+
+	annotations := manifest.Spec.Deployment.Spec.Template.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+		manifest.Spec.Deployment.Spec.Template.Annotations = annotations
+	}
+	annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation] = configMap.ResourceVersion
+	annotations[grafanaExtraVarsSecretResourceVersionAnnotation] = secret.ResourceVersion
+	return nil
+}
+
 func (r *GrafanaReconciler) handleGrafana(cr *monv1.PlatformMonitoring) error {
 	m, err := grafana(cr)
 	if err != nil {
 		r.Log.Error(err, "Failed creating Grafana manifest")
+		return err
+	}
+	if err = r.addGrafanaExtraVarsResourceVersions(context.TODO(), m.GetNamespace(), m); err != nil {
+		r.Log.Error(err, "Failed adding Grafana extra-vars resource versions")
 		return err
 	}
 

--- a/controllers/grafana/handlers.go
+++ b/controllers/grafana/handlers.go
@@ -56,19 +56,22 @@ func (r *GrafanaReconciler) addGrafanaExtraVarsResourceVersions(
 	secretFound := err == nil
 
 	annotations := manifest.Spec.Deployment.Spec.Template.Annotations
-	if annotations == nil {
-		annotations = make(map[string]string)
-		manifest.Spec.Deployment.Spec.Template.Annotations = annotations
+	setAnnotation := func(key, value string) {
+		if annotations == nil {
+			annotations = make(map[string]string)
+			manifest.Spec.Deployment.Spec.Template.Annotations = annotations
+		}
+		annotations[key] = value
 	}
 	if configMapFound {
-		annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation] = configMap.ResourceVersion
+		setAnnotation(grafanaExtraVarsConfigMapResourceVersionAnnotation, configMap.ResourceVersion)
 	} else if resourceVersion, ok := existingAnnotations[grafanaExtraVarsConfigMapResourceVersionAnnotation]; ok {
-		annotations[grafanaExtraVarsConfigMapResourceVersionAnnotation] = resourceVersion
+		setAnnotation(grafanaExtraVarsConfigMapResourceVersionAnnotation, resourceVersion)
 	}
 	if secretFound {
-		annotations[grafanaExtraVarsSecretResourceVersionAnnotation] = secret.ResourceVersion
+		setAnnotation(grafanaExtraVarsSecretResourceVersionAnnotation, secret.ResourceVersion)
 	} else if resourceVersion, ok := existingAnnotations[grafanaExtraVarsSecretResourceVersionAnnotation]; ok {
-		annotations[grafanaExtraVarsSecretResourceVersionAnnotation] = resourceVersion
+		setAnnotation(grafanaExtraVarsSecretResourceVersionAnnotation, resourceVersion)
 	}
 	return nil
 }

--- a/controllers/platformmonitoring_controller.go
+++ b/controllers/platformmonitoring_controller.go
@@ -331,16 +331,10 @@ func (r *PlatformMonitoringReconciler) Reconcile(context context.Context, reques
 func (r *PlatformMonitoringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&qubershiporgv1.PlatformMonitoring{}, builder.WithPredicates(ignoreDeletionPredicate())).
-		Watches(
-			&corev1.ConfigMap{},
-			handler.EnqueueRequestsFromMapFunc(r.requestsForPlatformMonitorings),
-			builder.WithPredicates(predicate.NewPredicateFuncs(isGrafanaExtraVarsConfigMap)),
-		).
-		Watches(
-			&corev1.Secret{},
-			handler.EnqueueRequestsFromMapFunc(r.requestsForPlatformMonitorings),
-			builder.WithPredicates(predicate.NewPredicateFuncs(isGrafanaExtraVarsSecret)),
-		).
+		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.requestsForPlatformMonitorings),
+			builder.WithPredicates(predicate.NewPredicateFuncs(isGrafanaExtraVarsConfigMap))).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.requestsForPlatformMonitorings),
+			builder.WithPredicates(predicate.NewPredicateFuncs(isGrafanaExtraVarsSecret))).
 		Complete(r)
 }
 

--- a/controllers/platformmonitoring_controller.go
+++ b/controllers/platformmonitoring_controller.go
@@ -42,14 +42,17 @@ import (
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/victoriametrics/vmsingle"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/victoriametrics/vmuser"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -327,9 +330,50 @@ func (r *PlatformMonitoringReconciler) Reconcile(context context.Context, reques
 // SetupWithManager sets up the controller with the Manager.
 func (r *PlatformMonitoringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&qubershiporgv1.PlatformMonitoring{}).
-		WithEventFilter(ignoreDeletionPredicate()).
+		For(&qubershiporgv1.PlatformMonitoring{}, builder.WithPredicates(ignoreDeletionPredicate())).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForPlatformMonitorings),
+			builder.WithPredicates(predicate.NewPredicateFuncs(isGrafanaExtraVarsConfigMap)),
+		).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.requestsForPlatformMonitorings),
+			builder.WithPredicates(predicate.NewPredicateFuncs(isGrafanaExtraVarsSecret)),
+		).
 		Complete(r)
+}
+
+func isGrafanaExtraVarsConfigMap(object client.Object) bool {
+	return object.GetName() == "grafana-extra-vars"
+}
+
+func isGrafanaExtraVarsSecret(object client.Object) bool {
+	return object.GetName() == "grafana-extra-vars-secret"
+}
+
+func (r *PlatformMonitoringReconciler) requestsForPlatformMonitorings(
+	ctx context.Context,
+	object client.Object,
+) []reconcile.Request {
+	platformMonitorings := &qubershiporgv1.PlatformMonitoringList{}
+	if err := r.List(ctx, platformMonitorings); err != nil {
+		r.Log.Error(err, "Cannot list PlatformMonitoring resources for Grafana extra-vars update")
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(platformMonitorings.Items))
+	for i := range platformMonitorings.Items {
+		platformMonitoring := &platformMonitorings.Items[i]
+		grafanaNamespace := platformMonitoring.GetNamespace()
+		if platformMonitoring.Spec.Grafana != nil && platformMonitoring.Spec.Grafana.Namespace != "" {
+			grafanaNamespace = platformMonitoring.Spec.Grafana.Namespace
+		}
+		if grafanaNamespace == object.GetNamespace() {
+			requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(platformMonitoring)})
+		}
+	}
+	return requests
 }
 
 func ignoreDeletionPredicate() predicate.Predicate {

--- a/controllers/platformmonitoring_controller_test.go
+++ b/controllers/platformmonitoring_controller_test.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	qubershiporgv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestRequestsForGrafanaExtraVars(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, qubershiporgv1.AddToScheme(scheme))
+	reconciler := &PlatformMonitoringReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&qubershiporgv1.PlatformMonitoring{
+			ObjectMeta: metav1.ObjectMeta{Name: "custom", Namespace: "monitoring"},
+			Spec: qubershiporgv1.PlatformMonitoringSpec{Grafana: &qubershiporgv1.Grafana{
+				Namespace: "grafana",
+			}},
+		},
+		&qubershiporgv1.PlatformMonitoring{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "other"}},
+	).Build()}
+
+	requests := reconciler.requestsForPlatformMonitorings(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars", Namespace: "grafana"},
+	})
+
+	assert.Equal(t, []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Name: "custom", Namespace: "monitoring",
+	}}}, requests)
+}
+
+func TestGrafanaExtraVarsResourcePredicates(t *testing.T) {
+	assert.True(t, isGrafanaExtraVarsConfigMap(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars"}}))
+	assert.False(t, isGrafanaExtraVarsConfigMap(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars-secret"}}))
+	assert.True(t, isGrafanaExtraVarsSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars-secret"}}))
+	assert.False(t, isGrafanaExtraVarsSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars"}}))
+}

--- a/controllers/platformmonitoring_controller_test.go
+++ b/controllers/platformmonitoring_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	qubershiporgv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,19 @@ func TestRequestsForGrafanaExtraVars(t *testing.T) {
 	assert.Equal(t, []reconcile.Request{{NamespacedName: types.NamespacedName{
 		Name: "custom", Namespace: "monitoring",
 	}}}, requests)
+}
+
+func TestRequestsForGrafanaExtraVarsReturnsNoRequestsWhenListFails(t *testing.T) {
+	reconciler := &PlatformMonitoringReconciler{
+		Client: fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+		Log:    logr.Discard(),
+	}
+
+	requests := reconciler.requestsForPlatformMonitorings(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars", Namespace: "grafana"},
+	})
+
+	assert.Empty(t, requests)
 }
 
 func TestGrafanaExtraVarsResourcePredicates(t *testing.T) {

--- a/docs/installation/components/grafana-stack/grafana.md
+++ b/docs/installation/components/grafana-stack/grafana.md
@@ -100,6 +100,26 @@ grafana:
   priorityClassName: priority-class
 ```
 
+#### Automatic internet access
+
+The chart disables Grafana's automatic plugin preinstallation and selected background update, analytics, plugin key,
+and news requests. The following environment variables are reserved and cannot be overridden through `extraVars` or
+`extraVarsSecret`:
+
+- `GF_PLUGINS_PREINSTALL_DISABLED=true`
+- `GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED=true`
+- `GF_ANALYTICS_CHECK_FOR_UPDATES=false`
+- `GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=false`
+- `GF_ANALYTICS_REPORTING_ENABLED=false`
+- `GF_NEWS_NEWS_FEED_ENABLED=false`
+
+Grafana plugins must be included in the `qubership-grafana-plugins-init` image. To add or update a plugin, release a new
+version of that image and update `grafana.operator.initContainerImage` in this chart. Grafana's `preinstall` and
+`preinstall_sync` options, including private download URLs, are not supported.
+
+These settings do not provide general network isolation. Data sources, OAuth providers, webhooks, and user actions can
+still initiate external requests. Use a NetworkPolicy or an equivalent firewall to enforce production egress rules.
+
 
 #### grafana-operator
 
@@ -203,4 +223,3 @@ grafana:
     port: 8282
     priorityClassName: priority-class
 ```
-

--- a/docs/installation/components/grafana-stack/grafana.md
+++ b/docs/installation/components/grafana-stack/grafana.md
@@ -106,9 +106,8 @@ grafana:
 
 #### Automatic internet access
 
-The chart disables Grafana's automatic plugin preinstallation and selected background update, analytics, plugin key,
-and news requests. The following environment variables are reserved and cannot be overridden through `extraVars` or
-`extraVarsSecret`:
+The chart disables Grafana's automatic suggested-plugin preinstallation and selected background update, analytics,
+plugin key, and news requests by default:
 
 - `GF_PLUGINS_PREINSTALL_DISABLED=true`
 - `GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED=true`
@@ -117,9 +116,17 @@ and news requests. The following environment variables are reserved and cannot b
 - `GF_ANALYTICS_REPORTING_ENABLED=false`
 - `GF_NEWS_NEWS_FEED_ENABLED=false`
 
-Grafana plugins must be included in the `qubership-grafana-plugins-init` image. To add or update a plugin, release a new
-version of that image and update `grafana.operator.initContainerImage` in this chart. Grafana's `preinstall` and
-`preinstall_sync` options, including private download URLs, are not supported.
+Override these settings through `extraVars` or `extraVarsSecret` for a connected environment. A nonempty effective
+`GF_PLUGINS_PREINSTALL` or `GF_PLUGINS_PREINSTALL_SYNC` value enables plugin preinstallation. Values from
+`extraVarsSecret` take precedence over duplicate `extraVars` keys. The plugin list supports pinned versions and private
+download URLs. The chart rejects a plugin list combined with an explicit `GF_PLUGINS_PREINSTALL_DISABLED=true` value.
+
+Plugins not configured through a preinstall list come from the `qubership-grafana-plugins-init` image. To change that
+set, release a new version of the image and update `grafana.operator.initContainerImage`.
+
+The monitoring operator copies the resource versions of `grafana-extra-vars` and `grafana-extra-vars-secret` to the
+Grafana pod template. In `WATCH_NAMESPACE`, changing either resource triggers a rollout without exposing the values in
+pod annotations. Resources in another namespace are detected during periodic reconciliation.
 
 These settings do not provide general network isolation. Data sources, OAuth providers, webhooks, and user actions can
 still initiate external requests. Use a NetworkPolicy or an equivalent firewall to enforce production egress rules.

--- a/docs/installation/components/grafana-stack/grafana.md
+++ b/docs/installation/components/grafana-stack/grafana.md
@@ -1,3 +1,7 @@
+<!-- This fragment is included in assembled documentation, where its heading level and cross-file anchors are valid. -->
+<!-- Keep the existing wide reference tables unchanged to avoid unrelated formatting churn. -->
+<!-- markdownlint-disable MD041 MD051 MD060 -->
+
 ### grafana
 
 <!-- markdownlint-disable line-length -->
@@ -119,7 +123,6 @@ version of that image and update `grafana.operator.initContainerImage` in this c
 
 These settings do not provide general network isolation. Data sources, OAuth providers, webhooks, and user actions can
 still initiate external requests. Use a NetworkPolicy or an equivalent firewall to enforce production egress rules.
-
 
 #### grafana-operator
 

--- a/tools/verify-grafana-offline-settings.sh
+++ b/tools/verify-grafana-offline-settings.sh
@@ -180,11 +180,11 @@ fi
 
 conflicting_preinstall_message="$(<"${conflicting_preinstall_error}")"
 case "${conflicting_preinstall_message}" in
-    *"GF_PLUGINS_PREINSTALL_DISABLED=true conflicts with GF_PLUGINS_PREINSTALL or GF_PLUGINS_PREINSTALL_SYNC"*) ;;
-    *)
-        echo "Grafana rejected conflicting preinstall settings without the expected error." >&2
-        exit 1
-        ;;
+*"GF_PLUGINS_PREINSTALL_DISABLED=true conflicts with GF_PLUGINS_PREINSTALL or GF_PLUGINS_PREINSTALL_SYNC"*) ;;
+*)
+    echo "Grafana rejected conflicting preinstall settings without the expected error." >&2
+    exit 1
+    ;;
 esac
 
 echo "Grafana offline settings render verification passed."

--- a/tools/verify-grafana-offline-settings.sh
+++ b/tools/verify-grafana-offline-settings.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+chart_dir="${1:-charts/qubership-monitoring-operator}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+yq_binary="${script_dir}/../bin/yq-4.53.2"
+temporary_dir="$(mktemp -d)"
+default_manifest="${temporary_dir}/default.yaml"
+override_manifest="${temporary_dir}/override.yaml"
+secret_manifest="${temporary_dir}/secret.yaml"
+config_override_values="${temporary_dir}/config-override-values.yaml"
+secret_override_values="${temporary_dir}/secret-override-values.yaml"
+trap 'rm -rf "${temporary_dir}"' EXIT
+
+if [[ ! -x "${yq_binary}" ]]; then
+    echo "The pinned yq binary is missing: ${yq_binary}. Run 'make yq' first." >&2
+    exit 1
+fi
+
+cat >"${config_override_values}" <<'EOF'
+grafana:
+  imageRenderer:
+    install: true
+  extraVars:
+    GF_PLUGINS_PREINSTALL_DISABLED: false
+    GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED: false
+    GF_ANALYTICS_CHECK_FOR_UPDATES: true
+    GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES: true
+    GF_ANALYTICS_REPORTING_ENABLED: true
+    GF_NEWS_NEWS_FEED_ENABLED: true
+    GF_RENDERING_CALLBACK_URL: ""
+    GF_RENDERING_SERVER_URL: ""
+    UNRELATED_CONFIG_VALUE: retained
+EOF
+
+cat >"${secret_override_values}" <<'EOF'
+grafana:
+  extraVarsSecret:
+    GF_PLUGINS_PREINSTALL_DISABLED: false
+    GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED: false
+    GF_ANALYTICS_CHECK_FOR_UPDATES: true
+    GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES: true
+    GF_ANALYTICS_REPORTING_ENABLED: true
+    GF_NEWS_NEWS_FEED_ENABLED: true
+    UNRELATED_SECRET_VALUE: retained
+EOF
+
+helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only charts/grafana/templates/configmap-extra-vars.yaml >"${default_manifest}"
+helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only charts/grafana/templates/configmap-extra-vars.yaml \
+    --values "${config_override_values}" >"${override_manifest}"
+helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only templates/oauth2-configs/secret-extra-vars-grafana.yaml \
+    --values "${secret_override_values}" >"${secret_manifest}"
+
+required_config_expression='select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
+    .data.GF_PLUGINS_PREINSTALL_DISABLED == "true" and
+    .data.GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED == "true" and
+    .data.GF_ANALYTICS_CHECK_FOR_UPDATES == "false" and
+    .data.GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES == "false" and
+    .data.GF_ANALYTICS_REPORTING_ENABLED == "false" and
+    .data.GF_NEWS_NEWS_FEED_ENABLED == "false"'
+
+for manifest in "${default_manifest}" "${override_manifest}"; do
+    if ! "${yq_binary}" eval-all -e "${required_config_expression}" "${manifest}" >/dev/null; then
+        echo "The rendered grafana-extra-vars ConfigMap does not enforce the offline settings." >&2
+        exit 1
+    fi
+done
+
+if ! "${yq_binary}" eval-all -e \
+    'select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
+        .data.UNRELATED_CONFIG_VALUE == "retained" and
+        .data.GF_RENDERING_SERVER_URL == "http://grafana-image-renderer:8081/render" and
+        .data.GF_RENDERING_CALLBACK_URL == "http://grafana-service:3000/"' \
+    "${override_manifest}" >/dev/null; then
+    echo "The rendered grafana-extra-vars ConfigMap does not preserve unrelated values." >&2
+    exit 1
+fi
+
+if ! "${yq_binary}" eval-all -e \
+    'select(.kind == "Secret" and .metadata.name == "grafana-extra-vars-secret") |
+        .stringData.UNRELATED_SECRET_VALUE == "retained" and
+        (.stringData | has("GF_PLUGINS_PREINSTALL_DISABLED") | not) and
+        (.stringData | has("GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED") | not) and
+        (.stringData | has("GF_ANALYTICS_CHECK_FOR_UPDATES") | not) and
+        (.stringData | has("GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES") | not) and
+        (.stringData | has("GF_ANALYTICS_REPORTING_ENABLED") | not) and
+        (.stringData | has("GF_NEWS_NEWS_FEED_ENABLED") | not)' \
+    "${secret_manifest}" >/dev/null; then
+    echo "The rendered grafana-extra-vars-secret Secret contains reserved keys or loses unrelated values." >&2
+    exit 1
+fi
+
+echo "Grafana offline settings render verification passed."

--- a/tools/verify-grafana-offline-settings.sh
+++ b/tools/verify-grafana-offline-settings.sh
@@ -14,12 +14,16 @@ empty_preinstall_manifest="${temporary_dir}/empty-preinstall.yaml"
 precedence_manifest="${temporary_dir}/precedence.yaml"
 conflicting_preinstall_manifest="${temporary_dir}/conflicting-preinstall.yaml"
 conflicting_preinstall_error="${temporary_dir}/conflicting-preinstall.err"
+invalid_config_value_error="${temporary_dir}/invalid-config-value.err"
+invalid_secret_value_error="${temporary_dir}/invalid-secret-value.err"
 config_override_values="${temporary_dir}/config-override-values.yaml"
 secret_override_values="${temporary_dir}/secret-override-values.yaml"
 custom_preinstall_values="${temporary_dir}/custom-preinstall-values.yaml"
 empty_preinstall_values="${temporary_dir}/empty-preinstall-values.yaml"
 precedence_values="${temporary_dir}/precedence-values.yaml"
 conflicting_preinstall_values="${temporary_dir}/conflicting-preinstall-values.yaml"
+invalid_config_value_values="${temporary_dir}/invalid-config-value-values.yaml"
+invalid_secret_value_values="${temporary_dir}/invalid-secret-value-values.yaml"
 trap 'rm -rf "${temporary_dir}"' EXIT
 
 if [[ ! -x "${yq_binary}" ]]; then
@@ -41,6 +45,8 @@ grafana:
     GF_RENDERING_CALLBACK_URL: ""
     GF_RENDERING_SERVER_URL: ""
     UNRELATED_CONFIG_VALUE: retained
+    UNRELATED_CONFIG_NUMBER: 42
+    UNRELATED_CONFIG_BOOLEAN: true
 EOF
 
 cat >"${secret_override_values}" <<'EOF'
@@ -53,6 +59,8 @@ grafana:
     GF_ANALYTICS_REPORTING_ENABLED: true
     GF_NEWS_NEWS_FEED_ENABLED: true
     UNRELATED_SECRET_VALUE: retained
+    UNRELATED_SECRET_NUMBER: 42
+    UNRELATED_SECRET_BOOLEAN: true
 EOF
 
 cat >"${custom_preinstall_values}" <<'EOF'
@@ -83,6 +91,20 @@ grafana:
     GF_PLUGINS_PREINSTALL_SYNC: private-plugin@1.2.3@https://plugins.internal.example/private-plugin.zip
 EOF
 
+cat >"${invalid_config_value_values}" <<'EOF'
+grafana:
+  extraVars:
+    INVALID_NESTED_VALUE:
+      child: value
+EOF
+
+cat >"${invalid_secret_value_values}" <<'EOF'
+grafana:
+  extraVarsSecret:
+    INVALID_NESTED_VALUE:
+      child: value
+EOF
+
 helm template monitoring "${chart_dir}" --namespace monitoring \
     --show-only charts/grafana/templates/configmap-extra-vars.yaml >"${default_manifest}"
 helm template monitoring "${chart_dir}" --namespace monitoring \
@@ -100,6 +122,30 @@ helm template monitoring "${chart_dir}" --namespace monitoring \
 helm template monitoring "${chart_dir}" --namespace monitoring \
     --show-only charts/grafana/templates/configmap-extra-vars.yaml \
     --values "${precedence_values}" >"${precedence_manifest}"
+
+if helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only charts/grafana/templates/configmap-extra-vars.yaml \
+    --values "${invalid_config_value_values}" >/dev/null 2>"${invalid_config_value_error}"; then
+    echo "grafana.extraVars accepts a nested object instead of a scalar value." >&2
+    exit 1
+fi
+if [[ "$(<"${invalid_config_value_error}")" != *"/extraVars/INVALID_NESTED_VALUE"* ]]; then
+    echo "grafana.extraVars failed for an unexpected reason:" >&2
+    sed 's/^/  /' "${invalid_config_value_error}" >&2
+    exit 1
+fi
+
+if helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only templates/oauth2-configs/secret-extra-vars-grafana.yaml \
+    --values "${invalid_secret_value_values}" >/dev/null 2>"${invalid_secret_value_error}"; then
+    echo "grafana.extraVarsSecret accepts a nested object instead of a scalar value." >&2
+    exit 1
+fi
+if [[ "$(<"${invalid_secret_value_error}")" != *"/extraVarsSecret/INVALID_NESTED_VALUE"* ]]; then
+    echo "grafana.extraVarsSecret failed for an unexpected reason:" >&2
+    sed 's/^/  /' "${invalid_secret_value_error}" >&2
+    exit 1
+fi
 
 required_config_expression='select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
     .data.GF_PLUGINS_PREINSTALL_DISABLED == "true" and
@@ -119,6 +165,8 @@ export EXPECTED_GRAFANA_CALLBACK_URL="http://grafana-service:3000/"             
 if ! "${yq_binary}" eval-all -e \
     'select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
         .data.UNRELATED_CONFIG_VALUE == "retained" and
+        .data.UNRELATED_CONFIG_NUMBER == "42" and
+        .data.UNRELATED_CONFIG_BOOLEAN == "true" and
         .data.GF_PLUGINS_PREINSTALL_DISABLED == "false" and
         .data.GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED == "false" and
         .data.GF_ANALYTICS_CHECK_FOR_UPDATES == "true" and
@@ -143,6 +191,8 @@ fi
 if ! "${yq_binary}" eval-all -e \
     'select(.kind == "Secret" and .metadata.name == "grafana-extra-vars-secret") |
         .stringData.UNRELATED_SECRET_VALUE == "retained" and
+        .stringData.UNRELATED_SECRET_NUMBER == "42" and
+        .stringData.UNRELATED_SECRET_BOOLEAN == "true" and
         .stringData.GF_PLUGINS_PREINSTALL_DISABLED == "false" and
         .stringData.GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED == "false" and
         .stringData.GF_ANALYTICS_CHECK_FOR_UPDATES == "true" and

--- a/tools/verify-grafana-offline-settings.sh
+++ b/tools/verify-grafana-offline-settings.sh
@@ -115,7 +115,7 @@ if ! "${yq_binary}" eval-all -e "${required_config_expression}" "${default_manif
 fi
 
 export EXPECTED_GRAFANA_RENDERER_URL="http://grafana-image-renderer:8081/render" # NOSONAR -- cluster-local service
-export EXPECTED_GRAFANA_CALLBACK_URL="http://grafana-service:3000/"             # NOSONAR -- cluster-local service
+export EXPECTED_GRAFANA_CALLBACK_URL="http://grafana-service:3000/"              # NOSONAR -- cluster-local service
 if ! "${yq_binary}" eval-all -e \
     'select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
         .data.UNRELATED_CONFIG_VALUE == "retained" and

--- a/tools/verify-grafana-offline-settings.sh
+++ b/tools/verify-grafana-offline-settings.sh
@@ -9,8 +9,17 @@ temporary_dir="$(mktemp -d)"
 default_manifest="${temporary_dir}/default.yaml"
 override_manifest="${temporary_dir}/override.yaml"
 secret_manifest="${temporary_dir}/secret.yaml"
+custom_preinstall_manifest="${temporary_dir}/custom-preinstall.yaml"
+empty_preinstall_manifest="${temporary_dir}/empty-preinstall.yaml"
+precedence_manifest="${temporary_dir}/precedence.yaml"
+conflicting_preinstall_manifest="${temporary_dir}/conflicting-preinstall.yaml"
+conflicting_preinstall_error="${temporary_dir}/conflicting-preinstall.err"
 config_override_values="${temporary_dir}/config-override-values.yaml"
 secret_override_values="${temporary_dir}/secret-override-values.yaml"
+custom_preinstall_values="${temporary_dir}/custom-preinstall-values.yaml"
+empty_preinstall_values="${temporary_dir}/empty-preinstall-values.yaml"
+precedence_values="${temporary_dir}/precedence-values.yaml"
+conflicting_preinstall_values="${temporary_dir}/conflicting-preinstall-values.yaml"
 trap 'rm -rf "${temporary_dir}"' EXIT
 
 if [[ ! -x "${yq_binary}" ]]; then
@@ -46,6 +55,34 @@ grafana:
     UNRELATED_SECRET_VALUE: retained
 EOF
 
+cat >"${custom_preinstall_values}" <<'EOF'
+grafana:
+  extraVars:
+    GF_PLUGINS_PREINSTALL_SYNC: private-plugin@1.2.3@https://plugins.internal.example/private-plugin.zip
+EOF
+
+cat >"${empty_preinstall_values}" <<'EOF'
+grafana:
+  extraVars:
+    GF_PLUGINS_PREINSTALL_SYNC: ""
+EOF
+
+cat >"${precedence_values}" <<'EOF'
+grafana:
+  extraVars:
+    GF_PLUGINS_PREINSTALL_DISABLED: true
+    GF_PLUGINS_PREINSTALL_SYNC: private-plugin@1.2.3@https://plugins.internal.example/private-plugin.zip
+  extraVarsSecret:
+    GF_PLUGINS_PREINSTALL_SYNC: ""
+EOF
+
+cat >"${conflicting_preinstall_values}" <<'EOF'
+grafana:
+  extraVars:
+    GF_PLUGINS_PREINSTALL_DISABLED: true
+    GF_PLUGINS_PREINSTALL_SYNC: private-plugin@1.2.3@https://plugins.internal.example/private-plugin.zip
+EOF
+
 helm template monitoring "${chart_dir}" --namespace monitoring \
     --show-only charts/grafana/templates/configmap-extra-vars.yaml >"${default_manifest}"
 helm template monitoring "${chart_dir}" --namespace monitoring \
@@ -54,6 +91,15 @@ helm template monitoring "${chart_dir}" --namespace monitoring \
 helm template monitoring "${chart_dir}" --namespace monitoring \
     --show-only templates/oauth2-configs/secret-extra-vars-grafana.yaml \
     --values "${secret_override_values}" >"${secret_manifest}"
+helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only charts/grafana/templates/configmap-extra-vars.yaml \
+    --values "${custom_preinstall_values}" >"${custom_preinstall_manifest}"
+helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only charts/grafana/templates/configmap-extra-vars.yaml \
+    --values "${empty_preinstall_values}" >"${empty_preinstall_manifest}"
+helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only charts/grafana/templates/configmap-extra-vars.yaml \
+    --values "${precedence_values}" >"${precedence_manifest}"
 
 required_config_expression='select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
     .data.GF_PLUGINS_PREINSTALL_DISABLED == "true" and
@@ -63,16 +109,20 @@ required_config_expression='select(.kind == "ConfigMap" and .metadata.name == "g
     .data.GF_ANALYTICS_REPORTING_ENABLED == "false" and
     .data.GF_NEWS_NEWS_FEED_ENABLED == "false"'
 
-for manifest in "${default_manifest}" "${override_manifest}"; do
-    if ! "${yq_binary}" eval-all -e "${required_config_expression}" "${manifest}" >/dev/null; then
-        echo "The rendered grafana-extra-vars ConfigMap does not enforce the offline settings." >&2
-        exit 1
-    fi
-done
+if ! "${yq_binary}" eval-all -e "${required_config_expression}" "${default_manifest}" >/dev/null; then
+    echo "The default grafana-extra-vars ConfigMap does not enable the offline settings." >&2
+    exit 1
+fi
 
 if ! "${yq_binary}" eval-all -e \
     'select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
         .data.UNRELATED_CONFIG_VALUE == "retained" and
+        .data.GF_PLUGINS_PREINSTALL_DISABLED == "false" and
+        .data.GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED == "false" and
+        .data.GF_ANALYTICS_CHECK_FOR_UPDATES == "true" and
+        .data.GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES == "true" and
+        .data.GF_ANALYTICS_REPORTING_ENABLED == "true" and
+        .data.GF_NEWS_NEWS_FEED_ENABLED == "true" and
         .data.GF_RENDERING_SERVER_URL == "http://grafana-image-renderer:8081/render" and
         .data.GF_RENDERING_CALLBACK_URL == "http://grafana-service:3000/"' \
     "${override_manifest}" >/dev/null; then
@@ -81,17 +131,60 @@ if ! "${yq_binary}" eval-all -e \
 fi
 
 if ! "${yq_binary}" eval-all -e \
-    'select(.kind == "Secret" and .metadata.name == "grafana-extra-vars-secret") |
-        .stringData.UNRELATED_SECRET_VALUE == "retained" and
-        (.stringData | has("GF_PLUGINS_PREINSTALL_DISABLED") | not) and
-        (.stringData | has("GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED") | not) and
-        (.stringData | has("GF_ANALYTICS_CHECK_FOR_UPDATES") | not) and
-        (.stringData | has("GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES") | not) and
-        (.stringData | has("GF_ANALYTICS_REPORTING_ENABLED") | not) and
-        (.stringData | has("GF_NEWS_NEWS_FEED_ENABLED") | not)' \
-    "${secret_manifest}" >/dev/null; then
-    echo "The rendered grafana-extra-vars-secret Secret contains reserved keys or loses unrelated values." >&2
+    'select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
+        .data.GF_PLUGINS_PREINSTALL_DISABLED == "true"' \
+    "${precedence_manifest}" >/dev/null; then
+    echo "An empty Secret preinstall value does not override the ConfigMap list." >&2
     exit 1
 fi
+
+if ! "${yq_binary}" eval-all -e \
+    'select(.kind == "Secret" and .metadata.name == "grafana-extra-vars-secret") |
+        .stringData.UNRELATED_SECRET_VALUE == "retained" and
+        .stringData.GF_PLUGINS_PREINSTALL_DISABLED == "false" and
+        .stringData.GF_PLUGINS_PUBLIC_KEY_RETRIEVAL_DISABLED == "false" and
+        .stringData.GF_ANALYTICS_CHECK_FOR_UPDATES == "true" and
+        .stringData.GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES == "true" and
+        .stringData.GF_ANALYTICS_REPORTING_ENABLED == "true" and
+        .stringData.GF_NEWS_NEWS_FEED_ENABLED == "true"' \
+    "${secret_manifest}" >/dev/null; then
+    echo "The rendered grafana-extra-vars-secret Secret does not preserve explicit overrides." >&2
+    exit 1
+fi
+
+if ! "${yq_binary}" eval-all -e \
+    'select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
+        .data.GF_PLUGINS_PREINSTALL_DISABLED == "false" and
+        .data.GF_PLUGINS_PREINSTALL_SYNC == "private-plugin@1.2.3@https://plugins.internal.example/private-plugin.zip"' \
+    "${custom_preinstall_manifest}" >/dev/null; then
+    echo "A custom Grafana preinstall list remains disabled." >&2
+    exit 1
+fi
+
+if ! "${yq_binary}" eval-all -e \
+    'select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
+        .data.GF_PLUGINS_PREINSTALL_DISABLED == "true" and
+        .data.GF_PLUGINS_PREINSTALL_SYNC == ""' \
+    "${empty_preinstall_manifest}" >/dev/null; then
+    echo "An empty Grafana preinstall list enables suggested-plugin preinstallation." >&2
+    exit 1
+fi
+
+if helm template monitoring "${chart_dir}" --namespace monitoring \
+    --show-only charts/grafana/templates/configmap-extra-vars.yaml \
+    --values "${conflicting_preinstall_values}" \
+    >"${conflicting_preinstall_manifest}" 2>"${conflicting_preinstall_error}"; then
+    echo "Grafana accepted a preinstall list while plugin preinstallation was explicitly disabled." >&2
+    exit 1
+fi
+
+conflicting_preinstall_message="$(<"${conflicting_preinstall_error}")"
+case "${conflicting_preinstall_message}" in
+    *"GF_PLUGINS_PREINSTALL_DISABLED=true conflicts with GF_PLUGINS_PREINSTALL or GF_PLUGINS_PREINSTALL_SYNC"*) ;;
+    *)
+        echo "Grafana rejected conflicting preinstall settings without the expected error." >&2
+        exit 1
+        ;;
+esac
 
 echo "Grafana offline settings render verification passed."

--- a/tools/verify-grafana-offline-settings.sh
+++ b/tools/verify-grafana-offline-settings.sh
@@ -114,6 +114,8 @@ if ! "${yq_binary}" eval-all -e "${required_config_expression}" "${default_manif
     exit 1
 fi
 
+export EXPECTED_GRAFANA_RENDERER_URL="http://grafana-image-renderer:8081/render" # NOSONAR -- cluster-local service
+export EXPECTED_GRAFANA_CALLBACK_URL="http://grafana-service:3000/"             # NOSONAR -- cluster-local service
 if ! "${yq_binary}" eval-all -e \
     'select(.kind == "ConfigMap" and .metadata.name == "grafana-extra-vars") |
         .data.UNRELATED_CONFIG_VALUE == "retained" and
@@ -123,8 +125,8 @@ if ! "${yq_binary}" eval-all -e \
         .data.GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES == "true" and
         .data.GF_ANALYTICS_REPORTING_ENABLED == "true" and
         .data.GF_NEWS_NEWS_FEED_ENABLED == "true" and
-        .data.GF_RENDERING_SERVER_URL == "http://grafana-image-renderer:8081/render" and
-        .data.GF_RENDERING_CALLBACK_URL == "http://grafana-service:3000/"' \
+        .data.GF_RENDERING_SERVER_URL == strenv(EXPECTED_GRAFANA_RENDERER_URL) and
+        .data.GF_RENDERING_CALLBACK_URL == strenv(EXPECTED_GRAFANA_CALLBACK_URL)' \
     "${override_manifest}" >/dev/null; then
     echo "The rendered grafana-extra-vars ConfigMap does not preserve unrelated values." >&2
     exit 1


### PR DESCRIPTION
## Why

Production and air-gapped environments may not provide internet access. Grafana's suggested-plugin installer attempts to download plugins from `storage.googleapis.com`, which causes startup timeouts and recurring error logs in those environments.

The operator needs offline defaults without removing the existing plugin configuration contract for connected deployments.

Closes #432.

## What changed

- Adds offline defaults for suggested-plugin preinstallation, plugin public-key retrieval, update checks, analytics reporting, and the news feed.
- Keeps all six settings configurable through `grafana.extraVars` and `grafana.extraVarsSecret`, with Secret values taking precedence over duplicate ConfigMap values.
- Allows arbitrary scalar environment variables under `extraVars` and `extraVarsSecret`. The schema accepts string, number, and boolean values without maintaining a list of Grafana-specific keys, and rejects nested objects and arrays.
- Enables plugin installation when the effective `GF_PLUGINS_PREINSTALL` or `GF_PLUGINS_PREINSTALL_SYNC` value is nonempty. Pinned versions and private download URLs remain supported.
- Rejects an explicit `GF_PLUGINS_PREINSTALL_DISABLED=true` value combined with a nonempty effective plugin list because the settings are contradictory.
- Watches `grafana-extra-vars` and `grafana-extra-vars-secret` and copies their resource versions to the Grafana pod template. Changes trigger a rollout without exposing configuration or Secret values in annotations.
- Allows either extra-vars resource to be absent during initial installation. If an existing resource is temporarily deleted, the controller preserves its last observed resource-version annotation to avoid rolling Grafana pods while a referenced `envFrom` source is unavailable. Kubernetes API errors other than `NotFound` still fail reconciliation.
- Adds schema validation, user documentation, Helm rendering checks, controller unit tests, and reconciliation coverage.

## Compatibility and operational behavior

This change does not require migration. Existing `preinstall` and `preinstall_sync` configurations remain supported. Plugins that are not configured through a preinstall list continue to come from the pinned `qubership-grafana-plugins-init` image.

Extra-vars resources in `WATCH_NAMESPACE` trigger reconciliation immediately. Resources in a separately configured Grafana namespace are detected during periodic reconciliation because the manager cache remains namespace-scoped.

These defaults disable known automatic Grafana requests. They do not provide general network isolation for data sources, OAuth providers, webhooks, or user actions. Use a NetworkPolicy or an equivalent firewall to enforce egress restrictions.

## How to verify

- `make test`
- `make envtest ENVTEST_K8S_VERSION=1.25.x!`
- `tools/verify-grafana-offline-settings.sh`
- Pre-commit hooks and Super-Linter, including `SHELL_SHFMT`
- Helm linting and rendering checks
- SonarCloud quality gate
- Monitoring clean-install integration pipeline
- kind `local-dev` upgrade with the PR operator image and live string, number, boolean, and Secret environment-variable checks, followed by rollback
- Independent adversarial review of the final implementation
