### PR TITLE
feat: deprecate managed Prometheus

### DIFF
--- a/charts/qubership-monitoring-operator/templates/NOTES.txt
+++ b/charts/qubership-monitoring-operator/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{ $.Chart.Name }} has been installed. Check pod statuses by running the command:
 kubectl --namespace {{ $.Release.Namespace }} get pods -l "app.kubernetes.io/part-of=monitoring"
-{{- if and .Values.prometheus .Values.prometheus.install }}
+{{- with include "monitoring.prometheusDeprecationWarning" . }}
 
-WARNING: Managed Prometheus is deprecated and will be removed in the next release. Migrate to VictoriaMetrics.
+WARNING: {{ . }}
 {{- end }}

--- a/charts/qubership-monitoring-operator/templates/NOTES.txt
+++ b/charts/qubership-monitoring-operator/templates/NOTES.txt
@@ -1,2 +1,6 @@
 {{ $.Chart.Name }} has been installed. Check pod statuses by running the command:
 kubectl --namespace {{ $.Release.Namespace }} get pods -l "app.kubernetes.io/part-of=monitoring"
+{{- if and .Values.prometheus .Values.prometheus.install }}
+
+WARNING: Managed Prometheus is deprecated and will be removed in the next release. Migrate to VictoriaMetrics.
+{{- end }}

--- a/charts/qubership-monitoring-operator/templates/_helpers.tpl
+++ b/charts/qubership-monitoring-operator/templates/_helpers.tpl
@@ -20,6 +20,15 @@ app.kubernetes.io/managed-by: {{ $ctx.Release.Service }}
 {{- end -}}
 
 {{/*
+Warn users who explicitly enable the deprecated managed Prometheus component.
+*/}}
+{{- define "monitoring.prometheusDeprecationWarning" -}}
+{{- if and .Values.prometheus .Values.prometheus.install -}}
+Managed Prometheus is deprecated and will be removed in the next release. Migrate to VictoriaMetrics.
+{{- end -}}
+{{- end -}}
+
+{{/*
 Extra labels helper: renders arbitrary labels map when provided.
 Usage:
   {{- include "monitoring.extraLabels" (dict "ctx" . "extraLabels" .Values.labels) | nindent 4 }}

--- a/controllers/platformmonitoring_controller.go
+++ b/controllers/platformmonitoring_controller.go
@@ -65,6 +65,14 @@ type PlatformMonitoringReconciler struct {
 	DiscoveryClient discovery.DiscoveryInterface
 }
 
+const (
+	prometheusDeprecationType    = "Deprecated"
+	prometheusDeprecationStatus  = "True"
+	prometheusDeprecationReason  = "PrometheusDeprecated"
+	prometheusDeprecationMessage = "Managed Prometheus is deprecated and will be removed in the next release. " +
+		"Migrate to VictoriaMetrics."
+)
+
 // +kubebuilder:rbac:groups=monitoring.netcracker.com,resources=platformmonitorings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=monitoring.netcracker.com,resources=platformmonitorings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=monitoring.netcracker.com,resources=platformmonitorings/finalizers,verbs=update
@@ -92,7 +100,9 @@ func (r *PlatformMonitoringReconciler) Reconcile(context context.Context, reques
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	managedPrometheusEnabled := managedPrometheusExplicitlyEnabled(customResourceInstance)
 	customResourceInstance.FillEmptyWithDefaults()
+	r.syncPrometheusDeprecationCondition(customResourceInstance, managedPrometheusEnabled)
 
 	r.Log.Info("Reconciliation started")
 	if err = r.updateStatus(customResourceInstance, "In progress", "False", "ReconcileCycleStatus", "Monitoring service reconcile cycle in progress"); err != nil {
@@ -359,6 +369,43 @@ func (r *PlatformMonitoringReconciler) removeStatus(customResourceInstance *qube
 		return true
 	}
 	return false
+}
+
+func managedPrometheusExplicitlyEnabled(customResourceInstance *qubershiporgv1.PlatformMonitoring) bool {
+	return customResourceInstance.Spec.Prometheus != nil &&
+		customResourceInstance.Spec.Prometheus.Install != nil &&
+		*customResourceInstance.Spec.Prometheus.Install
+}
+
+func (r *PlatformMonitoringReconciler) syncPrometheusDeprecationCondition(
+	customResourceInstance *qubershiporgv1.PlatformMonitoring,
+	enabled bool,
+) bool {
+	if !enabled {
+		return r.removeStatus(customResourceInstance, prometheusDeprecationReason)
+	}
+
+	idx, existingCondition := r.getCondition(customResourceInstance, prometheusDeprecationReason)
+	if existingCondition != nil &&
+		existingCondition.Type == prometheusDeprecationType &&
+		existingCondition.Status == prometheusDeprecationStatus &&
+		existingCondition.Message == prometheusDeprecationMessage {
+		return false
+	}
+
+	condition := qubershiporgv1.PlatformMonitoringCondition{
+		Type:               prometheusDeprecationType,
+		Status:             prometheusDeprecationStatus,
+		Reason:             prometheusDeprecationReason,
+		Message:            prometheusDeprecationMessage,
+		LastTransitionTime: metav1.Now().String(),
+	}
+	if existingCondition == nil {
+		customResourceInstance.Status.Conditions = append(customResourceInstance.Status.Conditions, condition)
+	} else {
+		customResourceInstance.Status.Conditions[idx] = condition
+	}
+	return true
 }
 
 // updateStatus updates condition of custom resource instance

--- a/controllers/platformmonitoring_deprecation_test.go
+++ b/controllers/platformmonitoring_deprecation_test.go
@@ -1,0 +1,125 @@
+package controllers
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+)
+
+func TestManagedPrometheusExplicitlyEnabled(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	disabled := false
+	tests := []struct {
+		name       string
+		prometheus *monv1.Prometheus
+		want       bool
+	}{
+		{name: "missing prometheus spec"},
+		{name: "missing install value", prometheus: &monv1.Prometheus{}},
+		{name: "explicitly disabled", prometheus: &monv1.Prometheus{Install: &disabled}},
+		{name: "explicitly enabled", prometheus: &monv1.Prometheus{Install: &enabled}, want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			instance := &monv1.PlatformMonitoring{
+				Spec: monv1.PlatformMonitoringSpec{Prometheus: test.prometheus},
+			}
+			if got := managedPrometheusExplicitlyEnabled(instance); got != test.want {
+				t.Fatalf("managedPrometheusExplicitlyEnabled() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSyncPrometheusDeprecationCondition(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PlatformMonitoringReconciler{}
+	unrelated := monv1.PlatformMonitoringCondition{
+		Type:               "Successful",
+		Status:             "True",
+		Reason:             "ReconcileCycleStatus",
+		Message:            "Monitoring service reconcile cycle succeeded",
+		LastTransitionTime: "unchanged",
+	}
+	instance := &monv1.PlatformMonitoring{
+		Status: monv1.PlatformMonitoringStatus{Conditions: []monv1.PlatformMonitoringCondition{unrelated}},
+	}
+
+	if changed := reconciler.syncPrometheusDeprecationCondition(instance, true); !changed {
+		t.Fatal("expected enabling managed Prometheus to add the deprecation condition")
+	}
+	if len(instance.Status.Conditions) != 2 {
+		t.Fatalf("expected two conditions, got %d", len(instance.Status.Conditions))
+	}
+	condition := conditionByReason(t, instance, prometheusDeprecationReason)
+	if condition.Type != prometheusDeprecationType || condition.Status != prometheusDeprecationStatus ||
+		condition.Message != prometheusDeprecationMessage || condition.LastTransitionTime == "" {
+		t.Fatalf("unexpected deprecation condition: %#v", condition)
+	}
+	originalTransitionTime := condition.LastTransitionTime
+
+	if changed := reconciler.syncPrometheusDeprecationCondition(instance, true); changed {
+		t.Fatal("expected an unchanged deprecation condition to remain stable")
+	}
+	condition = conditionByReason(t, instance, prometheusDeprecationReason)
+	if condition.LastTransitionTime != originalTransitionTime {
+		t.Fatalf("transition time changed from %q to %q", originalTransitionTime, condition.LastTransitionTime)
+	}
+
+	if changed := reconciler.syncPrometheusDeprecationCondition(instance, false); !changed {
+		t.Fatal("expected disabling managed Prometheus to remove the deprecation condition")
+	}
+	if len(instance.Status.Conditions) != 1 || instance.Status.Conditions[0] != unrelated {
+		t.Fatalf("expected only the unrelated condition to remain, got %#v", instance.Status.Conditions)
+	}
+	if changed := reconciler.syncPrometheusDeprecationCondition(instance, false); changed {
+		t.Fatal("expected removing an absent deprecation condition to be a no-op")
+	}
+}
+
+func TestSyncPrometheusDeprecationConditionRepairsStaleFields(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PlatformMonitoringReconciler{}
+	instance := &monv1.PlatformMonitoring{
+		Status: monv1.PlatformMonitoringStatus{Conditions: []monv1.PlatformMonitoringCondition{{
+			Type:               prometheusDeprecationType,
+			Status:             prometheusDeprecationStatus,
+			Reason:             prometheusDeprecationReason,
+			Message:            "stale message",
+			LastTransitionTime: "stale transition time",
+		}}},
+	}
+
+	if changed := reconciler.syncPrometheusDeprecationCondition(instance, true); !changed {
+		t.Fatal("expected stale deprecation fields to be repaired")
+	}
+	condition := conditionByReason(t, instance, prometheusDeprecationReason)
+	if condition.Message != prometheusDeprecationMessage {
+		t.Fatalf("message = %q, want %q", condition.Message, prometheusDeprecationMessage)
+	}
+	if condition.LastTransitionTime == "stale transition time" {
+		t.Fatal("expected stale transition time to be replaced")
+	}
+}
+
+func conditionByReason(
+	t *testing.T,
+	instance *monv1.PlatformMonitoring,
+	reason string,
+) monv1.PlatformMonitoringCondition {
+	t.Helper()
+	for _, condition := range instance.Status.Conditions {
+		if condition.Reason == reason {
+			return condition
+		}
+	}
+	t.Fatalf("condition with reason %q was not found", reason)
+	return monv1.PlatformMonitoringCondition{}
+}

--- a/docs/user-guides/migrate-from-prometheus-to-victoriametrics.md
+++ b/docs/user-guides/migrate-from-prometheus-to-victoriametrics.md
@@ -1,6 +1,12 @@
-This guide describes how to migrate from Prometheus to VictoriaMetrics.
+# Migrate from Prometheus to VictoriaMetrics
 
-# Overview
+## Overview
+
+> **Deprecated:** The Prometheus instance managed by `prometheus.install` remains available in this release but will be
+> removed in the next release. Migrate metric storage and scraping to VictoriaMetrics.
+>
+> This deprecation does not apply to PromQL, Prometheus-format metrics, `ServiceMonitor`, `PodMonitor`,
+> `PrometheusRule`, Alertmanager, or Prometheus Operator APIs shared with VictoriaMetrics.
 
 Monitoring can work with Prometheus or VictoriaMetrics stack. It is two different TSDB and you can choose between them.
 We recommend use VictoriaMetrics instead of Prometheus since monitoring-operator `v0.55`. If you used Prometheus before
@@ -42,7 +48,7 @@ Example:
 ....
 prometheus:
   install: false
-    
+
 alertManager:
   install: false
 
@@ -128,7 +134,7 @@ prometheus:
 
 alertManager:
   install: false
-  
+
 ....
 victorimetrics:
   vmOperator:
@@ -157,8 +163,8 @@ for all parameters [see here](../installation/README.md#victoria-metrics)
 
 Step 4. Run `vmctl` tool
 
-After successful deploy you can import snapshots to the TSDB. VictoriaMetrics has `vmctl` tool for it. More information
-[here](https://docs.victoriametrics.com/vmctl.html#migrating-data-from-prometheus).
+After successful deploy you can import snapshots to the TSDB. VictoriaMetrics has `vmctl` tool for it. See the
+[vmctl migration documentation](https://docs.victoriametrics.com/vmctl.html#migrating-data-from-prometheus).
 
 * You can run tool locally:
 
@@ -195,7 +201,7 @@ After successful deploy you can import snapshots to the TSDB. VictoriaMetrics ha
             args:
               - while true; do sleep 30; done;
   ```
-  
+
   **NOTE**: You should mount or upload Prometheus backup to pod with vmctl tool.
 
 The `vmctl` tool has a lot of flags it is just main parameters. But you can filter data in snapshot and upload not all

--- a/docs/user-guides/migrate-from-prometheus-to-victoriametrics.md
+++ b/docs/user-guides/migrate-from-prometheus-to-victoriametrics.md
@@ -88,7 +88,7 @@ Step 1. Make Prometheus snapshot
 
 TSDB Admin APIs allows doing snapshots. You should to send POST request on Prometheus endpoint
 `/api/v1/admin/tsdb/snapshot`. The request can be sent from local host via Kubernetes ingress
-(connected with Prometheus) or from Kubernetes pod that has a tool that allows to do POST request (e.g. curl).
+(connected with Prometheus) or from Kubernetes pod that has a tool that allows to do POST request (e.g. cURL).
 
 ```shell
 curl -XPOST http://<your_prometheus_URL>/api/v1/admin/tsdb/snapshot

--- a/tools/verify-helm-crds.sh
+++ b/tools/verify-helm-crds.sh
@@ -198,7 +198,7 @@ verify_prometheus_deprecation_note() {
     local output_file="${temporary_dir}/prometheus-deprecation-${case_name}.txt"
     helm install "prometheus-deprecation-${case_name}" "${chart_dir}" \
         --namespace monitoring \
-        --dry-run=client \
+        --dry-run \
         "$@" \
         >"${output_file}"
 

--- a/tools/verify-helm-crds.sh
+++ b/tools/verify-helm-crds.sh
@@ -189,6 +189,18 @@ verify_kubernetes_version_guard "${chart_dir}"
 verify_kubernetes_version_guard "${chart_dir}/../qubership-monitoring-crds"
 
 prometheus_deprecation_warning="Managed Prometheus is deprecated and will be removed in the next release. Migrate to VictoriaMetrics."
+prometheus_deprecation_chart="${temporary_dir}/prometheus-deprecation-chart"
+
+cp -R "${chart_dir}" "${prometheus_deprecation_chart}"
+cat >"${prometheus_deprecation_chart}/templates/prometheus-deprecation-test.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-deprecation-notes-test
+data:
+  warning: |-
+{{ include "monitoring.prometheusDeprecationWarning" . | nindent 4 }}
+EOF
 
 verify_prometheus_deprecation_note() {
     local case_name="$1"
@@ -196,9 +208,9 @@ verify_prometheus_deprecation_note() {
     shift 2
 
     local output_file="${temporary_dir}/prometheus-deprecation-${case_name}.txt"
-    helm install "prometheus-deprecation-${case_name}" "${chart_dir}" \
+    helm template "prometheus-deprecation-${case_name}" "${prometheus_deprecation_chart}" \
         --namespace monitoring \
-        --dry-run \
+        --show-only templates/prometheus-deprecation-test.yaml \
         "$@" \
         >"${output_file}"
 

--- a/tools/verify-helm-crds.sh
+++ b/tools/verify-helm-crds.sh
@@ -188,6 +188,36 @@ verify_kubernetes_version_guard() {
 verify_kubernetes_version_guard "${chart_dir}"
 verify_kubernetes_version_guard "${chart_dir}/../qubership-monitoring-crds"
 
+prometheus_deprecation_warning="Managed Prometheus is deprecated and will be removed in the next release. Migrate to VictoriaMetrics."
+
+verify_prometheus_deprecation_note() {
+    local case_name="$1"
+    local expected_count="$2"
+    shift 2
+
+    local output_file="${temporary_dir}/prometheus-deprecation-${case_name}.txt"
+    helm install "prometheus-deprecation-${case_name}" "${chart_dir}" \
+        --namespace monitoring \
+        --dry-run=client \
+        "$@" \
+        >"${output_file}"
+
+    local actual_count
+    actual_count="$(grep -Fc "${prometheus_deprecation_warning}" "${output_file}" || true)"
+    if [[ "${actual_count}" -ne "${expected_count}" ]]; then
+        echo "The ${case_name} Helm notes contain ${actual_count} Prometheus deprecation warnings;" \
+            "expected ${expected_count}." >&2
+        exit 1
+    fi
+}
+
+verify_prometheus_deprecation_note default 0
+verify_prometheus_deprecation_note disabled 0 --set prometheus.install=false
+verify_prometheus_deprecation_note enabled 1 --set prometheus.install=true
+verify_prometheus_deprecation_note with-victoriametrics 1 \
+    --set prometheus.install=true \
+    --set victoriametrics.vmOperator.install=true
+
 verify_servicemonitor_crd_count() {
     local prometheus_install="$1"
     local victoriametrics_install="$2"

--- a/tools/verify-helm-crds.sh
+++ b/tools/verify-helm-crds.sh
@@ -192,15 +192,19 @@ prometheus_deprecation_warning="Managed Prometheus is deprecated and will be rem
 prometheus_deprecation_chart="${temporary_dir}/prometheus-deprecation-chart"
 
 cp -R "${chart_dir}" "${prometheus_deprecation_chart}"
-cat >"${prometheus_deprecation_chart}/templates/prometheus-deprecation-test.yaml" <<'EOF'
+prometheus_deprecation_notes="${prometheus_deprecation_chart}/templates/NOTES.txt"
+prometheus_deprecation_test_template="${prometheus_deprecation_chart}/templates/prometheus-deprecation-test.yaml"
+{
+    cat <<'EOF'
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-deprecation-notes-test
 data:
-  warning: |-
-{{ include "monitoring.prometheusDeprecationWarning" . | nindent 4 }}
+  notes: |-
 EOF
+    sed 's/^/    /' "${prometheus_deprecation_notes}"
+} >"${prometheus_deprecation_test_template}"
 
 verify_prometheus_deprecation_note() {
     local case_name="$1"


### PR DESCRIPTION
# What does this PR do?

Adds a Helm warning and a non-failing PlatformMonitoring status condition when managed Prometheus is explicitly enabled. The warning remains stable across reconciliation cycles and is removed when Prometheus is disabled.

The documentation clarifies that PromQL, Prometheus-format metrics, monitoring CRs, Alertmanager, and shared Prometheus Operator APIs are not deprecated.

## Why

Managed Prometheus remains available in this release but is planned for removal in the next release. Users need an explicit migration warning without changes to existing values, defaults, APIs, or installation behavior.

Closes #431.

## Checklist

- [x] `make generate` is not required because `api/v1/*.go` did not change
- [x] `make test` and `make envtest` pass
- [x] Helm verification and lint pass
- [x] User-facing documentation is updated; CRDs are unchanged
