### PR TITLE
fix(renovate): group bundled operator updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,9 @@ DOCKERFILE=cmd/operator/Dockerfile
 # `make update-prometheus-crds PROMETHEUS_OPERATOR_VERSION=0.92.1`)
 CRD_UPDATE_TOOL=tools/crd-update/crd-update.py
 PYTHON?=python3
+# renovate: datasource=docker depName=quay.io/prometheus-operator/prometheus-operator
 PROMETHEUS_OPERATOR_VERSION?=0.92.1
+# renovate: datasource=docker depName=victoriametrics/operator
 VICTORIAMETRICS_OPERATOR_VERSION?=0.73.1
 GRAFANA_OPERATOR_VERSION?=5.24.0
 LOCALBIN ?= $(CURDIR)/bin

--- a/controllers/victoriametrics/vmoperator/assets/deployment.yaml
+++ b/controllers/victoriametrics/vmoperator/assets/deployment.yaml
@@ -53,6 +53,7 @@ spec:
           value: 50Mi
         - name: VM_VMALERTMANAGER_CONFIGRELOADERMEMORY
           value: 50Mi
+        # renovate-vm-operator
         image: victoriametrics/operator:v0.73.1
         imagePullPolicy: IfNotPresent
         name: victoriametrics-operator

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,20 @@
         "\\{\\{-?[\\t ]*/\\*[\\t ]+#?[\\t ]*renovate: datasource=(?<datasource>docker) depName=(?<depName>victoriametrics/operator)[\\t ]*\\*/[\\t ]*-?\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{-?[\\t ]*print[\\t ]+\\\"[^\\\"\\r\\n]+:(?<currentValue>config-reloader-v\\d+\\.\\d+\\.\\d+)\\\"[\\t ]*-?\\}\\}"
       ],
       "versioningTemplate": "regex:^config-reloader-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update the VictoriaMetrics operator image in the bundled deployment asset",
+      "managerFilePatterns": [
+        "/^controllers/victoriametrics/vmoperator/assets/deployment\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate-vm-operator[^\\S\\r\\n]*\\r?\\n[\\t ]*image:[\\t ]+victoriametrics/operator:v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "victoriametrics/operator",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver-coerced",
+      "depTypeTemplate": "annotated-version"
     }
   ],
   "packageRules": [
@@ -43,22 +57,10 @@
       "pinDigests": false
     },
     {
-      "description": "Group repository-specific Kubernetes-related Go modules",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "k8s.io/{/,}**",
-        "sigs.k8s.io/{/,}**",
-        "github.com/openshift/**",
-        "github.com/prometheus-operator/prometheus-operator{/,}**",
-        "github.com/VictoriaMetrics/{/,}**"
-      ],
-      "groupName": "k8s-go-modules"
-    },
-    {
-      "description": "Group controller-gen Makefile tool into k8s-go-modules",
+      "description": "Group controller-gen Makefile tool with Kubernetes Go modules",
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["sigs.k8s.io/controller-tools"],
-      "groupName": "k8s-go-modules"
+      "groupName": "Kubernetes Go modules"
     },
     {
       "description": "Group all third-party docker images, base images, and pip packages",
@@ -82,6 +84,29 @@
       "matchPackageNames": ["Netcracker/qubership-test-pipelines"],
       "groupName": "netcracker-workflows",
       "separateMajorMinor": false
+    },
+    {
+      "description": "Keep Prometheus Operator APIs, runtime images, and CRD source version together",
+      "matchPackageNames": [
+        "github.com/prometheus-operator/prometheus-operator{/,}**",
+        "quay.io/prometheus-operator/prometheus-operator",
+        "quay.io/prometheus-operator/prometheus-config-reloader"
+      ],
+      "groupName": "Prometheus Operator",
+      "prBodyNotes": [
+        "This repository bundles Prometheus Operator APIs and assets. Run `make generate-all`, review the generated CRDs and API changes, synchronize custom deployment/RBAC assets when upstream changed them, and commit the reviewed results."
+      ]
+    },
+    {
+      "description": "Keep VictoriaMetrics Operator APIs, runtime images, and CRD source version together",
+      "matchPackageNames": [
+        "github.com/VictoriaMetrics/operator{/,}**",
+        "victoriametrics/operator"
+      ],
+      "groupName": "VictoriaMetrics Operator",
+      "prBodyNotes": [
+        "This repository bundles VictoriaMetrics Operator APIs and assets. Run `make generate-all`, review the generated CRDs and API changes, synchronize custom deployment/RBAC assets when upstream changed them, and commit the reviewed results."
+      ]
     },
     {
       "description": "VictoriaMetrics cluster images use -cluster docker tag suffix (vmselect, vmstorage, vminsert)",


### PR DESCRIPTION
# What does this PR do?

Splits bundled Prometheus Operator and VictoriaMetrics Operator dependencies into focused Renovate groups. It also registers the CRD source versions and bundled VictoriaMetrics deployment image, and aligns controller-gen with the shared Kubernetes group.

## Why

Renovate PR #399 combines unrelated operator API upgrades without updating the matching runtime images, CRD source versions, or bundled assets. Focused groups keep detected version references together and tell reviewers to regenerate CRDs and review API, deployment, and RBAC changes.

## Checklist

- [x] Strict Renovate configuration validation passes.
- [x] Local extraction detects each added version reference once.
- [x] Targeted lookups create separate Kubernetes, Prometheus Operator, and VictoriaMetrics Operator groups.
- [x] `make generate` is not required because this PR does not change APIs or generated files.