### PR TITLE
chore: add cluster_engine matrix (kind/microshift) to integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -63,10 +63,18 @@ jobs:
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           github.event.pull_request.user.login != 'renovate[bot]'
         )
-    uses: netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@edbd2ff8ec59df921e28f1311d42e0a974f19391 # v1.14.2
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster_engine: [kind, microshift]
+    # TEST BRANCH ONLY: pinned to the feat/monitoring-openshift branch so the
+    # cluster_engine=microshift leg can be exercised before that branch is merged
+    # and released. Must be re-pinned to a tagged qubership-test-pipelines SHA
+    # (with the matching renovate depName comment) before this is merged to main.
+    uses: netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@feat/monitoring-openshift
     with:
       service_branch: ${{ github.sha }}
-      pipeline_branch: 'edbd2ff8ec59df921e28f1311d42e0a974f19391' # v1.14.2 renovate: depName=Netcracker/qubership-test-pipelines
+      pipeline_branch: 'feat/monitoring-openshift'
       repository_name: '${{ github.repository_owner }}/qubership-monitoring-operator'
       kind-layout: 'single-node'
-      enable-owner-references-permission-enforcement: true
+      cluster_engine: ${{ matrix.cluster_engine }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -66,7 +66,7 @@ jobs:
     uses: netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@57a9fbc96d458a7bdc37cb919bad53937d7d08dd # v1.15.0
     with:
       service_branch: ${{ github.sha }}
-      pipeline_branch: '57a9fbc96d458a7bdc37cb919bad53937d7d08dd'
+      pipeline_branch: '57a9fbc96d458a7bdc37cb919bad53937d7d08dd' # v1.15.0 renovate: depName=Netcracker/qubership-test-pipelines
       repository_name: '${{ github.repository_owner }}/qubership-monitoring-operator'
       kind-layout: 'single-node'
       enable-owner-references-permission-enforcement: true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -63,15 +63,10 @@ jobs:
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           github.event.pull_request.user.login != 'renovate[bot]'
         )
-    # TEST BRANCH ONLY: pinned to the feat/monitoring-openshift branch so the kind and
-    # microshift legs (both now produced by that workflow's own scope: pr matrix) can be
-    # exercised before that branch is merged and released. Must be re-pinned to a tagged
-    # qubership-test-pipelines SHA (with the matching renovate depName comment) before this
-    # is merged to main.
-    uses: netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@feat/monitoring-openshift
+    uses: netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@57a9fbc96d458a7bdc37cb919bad53937d7d08dd # v1.15.0
     with:
       service_branch: ${{ github.sha }}
-      pipeline_branch: 'feat/monitoring-openshift'
+      pipeline_branch: '57a9fbc96d458a7bdc37cb919bad53937d7d08dd'
       repository_name: '${{ github.repository_owner }}/qubership-monitoring-operator'
       kind-layout: 'single-node'
       enable-owner-references-permission-enforcement: true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -63,18 +63,15 @@ jobs:
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           github.event.pull_request.user.login != 'renovate[bot]'
         )
-    strategy:
-      fail-fast: false
-      matrix:
-        cluster_engine: [kind, microshift]
-    # TEST BRANCH ONLY: pinned to the feat/monitoring-openshift branch so the
-    # cluster_engine=microshift leg can be exercised before that branch is merged
-    # and released. Must be re-pinned to a tagged qubership-test-pipelines SHA
-    # (with the matching renovate depName comment) before this is merged to main.
+    # TEST BRANCH ONLY: pinned to the feat/monitoring-openshift branch so the kind and
+    # microshift legs (both now produced by that workflow's own scope: pr matrix) can be
+    # exercised before that branch is merged and released. Must be re-pinned to a tagged
+    # qubership-test-pipelines SHA (with the matching renovate depName comment) before this
+    # is merged to main.
     uses: netcracker/qubership-test-pipelines/.github/workflows/monitoring.yaml@feat/monitoring-openshift
     with:
       service_branch: ${{ github.sha }}
       pipeline_branch: 'feat/monitoring-openshift'
       repository_name: '${{ github.repository_owner }}/qubership-monitoring-operator'
       kind-layout: 'single-node'
-      cluster_engine: ${{ matrix.cluster_engine }}
+      enable-owner-references-permission-enforcement: true


### PR DESCRIPTION
# What does this PR do?

Extends `integration-tests.yaml` workflow with microshift (crc openshift deploy)

## Why

We need to be sure that all code changes still support deploy on both k8s and openshift platforms. 

## Checklist

- [*] `make generate` re-run if `api/v1/*.go` changed 
- [*] `make test` passes
- [*] Docs / CRDs updated if user-facing

