### PR TITLE
fix(dashboard): remove hidden Unicode characters

### DIFF
--- a/controllers/grafana-operator/assets/grafana-dashboards/alerts-overview.yaml
+++ b/controllers/grafana-operator/assets/grafana-dashboards/alerts-overview.yaml
@@ -72,7 +72,7 @@ spec:
           "title": "Pod Resources",
           "tooltip": "",
           "type": "link",
-          "url": "./d/{% printf `%.40s` (printf `%s-%s` .Release.Namespace (index .DashboardsUIDs `kubernetes-pod-resources`) ) %}/kubernetes-pod-resources?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace﻿﻿﻿﻿&var-pod=﻿﻿$instance"
+          "url": "./d/{% printf `%.40s` (printf `%s-%s` .Release.Namespace (index .DashboardsUIDs `kubernetes-pod-resources`) ) %}/kubernetes-pod-resources?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$instance"
         }
       ],
       "liveNow": false,


### PR DESCRIPTION
## Why

The Renovate Dependency Dashboard reports hidden Unicode in the repository. Six U+FEFF characters are embedded in a Grafana dashboard URL and contaminate the namespace and pod query values.

## What

Remove the hidden characters without changing the dashboard path, query keys, or Grafana variables.

## How to verify

- Scan tracked text for hidden formatting characters.
- Run helm lint charts/qubership-monitoring-operator.
- Run go test ./controllers/grafana-operator/....

Related to #333.