### PR TITLE
fix: skip no-op GrafanaDashboard updates on reconcile

### DIFF
--- a/controllers/grafana-operator/handlers.go
+++ b/controllers/grafana-operator/handlers.go
@@ -2,6 +2,7 @@ package grafana_operator
 
 import (
 	"context"
+	"reflect"
 
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
@@ -226,9 +227,20 @@ func (r *GrafanaOperatorReconciler) handleGrafanaDashboard(fileName string, cr *
 			return err
 		}
 
-		checkObj.SetLabels(m.GetLabels())
-		checkObj.Spec = m.Spec
-
+		// Only update when Spec or labels actually changed to avoid rewriting large
+		// dashboard CRs on every PlatformMonitoring reconcile (#447).
+		needsUpdate := false
+		if !reflect.DeepEqual(checkObj.Spec, m.Spec) {
+			checkObj.Spec = m.Spec
+			needsUpdate = true
+		}
+		if !reflect.DeepEqual(checkObj.GetLabels(), m.GetLabels()) {
+			checkObj.SetLabels(m.GetLabels())
+			needsUpdate = true
+		}
+		if !needsUpdate {
+			return nil
+		}
 		return r.UpdateResource(checkObj)
 	})
 }

--- a/controllers/grafana-operator/handlers_test.go
+++ b/controllers/grafana-operator/handlers_test.go
@@ -1,0 +1,114 @@
+package grafana_operator
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	grafv1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const testDashboardAsset = "home-dashboard.yaml"
+
+func testPlatformMonitoring() *monv1.PlatformMonitoring {
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Grafana: &monv1.Grafana{},
+		},
+	}
+}
+
+func newGrafanaDashboardTestReconciler(t *testing.T, objs ...client.Object) *GrafanaOperatorReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, grafv1.AddToScheme(scheme))
+	return &GrafanaOperatorReconciler{
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+			Scheme: scheme,
+			Log:    utils.Logger("grafanaoperator_dashboard_test"),
+		},
+	}
+}
+
+func TestHandleGrafanaDashboardCreate(t *testing.T) {
+	cr := testPlatformMonitoring()
+	desired, err := grafanaDashboard(cr, testDashboardAsset)
+	require.NoError(t, err)
+
+	r := newGrafanaDashboardTestReconciler(t, cr)
+	require.NoError(t, r.handleGrafanaDashboard(testDashboardAsset, cr))
+
+	got := &grafv1.GrafanaDashboard{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, desired.Name, got.Name)
+	assert.Equal(t, desired.Spec.ResyncPeriod, got.Spec.ResyncPeriod)
+}
+
+func TestHandleGrafanaDashboardSkipsNoOpUpdate(t *testing.T) {
+	cr := testPlatformMonitoring()
+	desired, err := grafanaDashboard(cr, testDashboardAsset)
+	require.NoError(t, err)
+	desired.ResourceVersion = "1"
+
+	r := newGrafanaDashboardTestReconciler(t, cr, desired.DeepCopy())
+	require.NoError(t, r.handleGrafanaDashboard(testDashboardAsset, cr))
+
+	got := &grafv1.GrafanaDashboard{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
+}
+
+func TestHandleGrafanaDashboardUpdatesChangedSpec(t *testing.T) {
+	cr := testPlatformMonitoring()
+	desired, err := grafanaDashboard(cr, testDashboardAsset)
+	require.NoError(t, err)
+
+	stale := desired.DeepCopy()
+	stale.ResourceVersion = "1"
+	stale.Spec.ResyncPeriod = metav1.Duration{Duration: desired.Spec.ResyncPeriod.Duration * 2}
+
+	r := newGrafanaDashboardTestReconciler(t, cr, stale)
+	require.NoError(t, r.handleGrafanaDashboard(testDashboardAsset, cr))
+
+	got := &grafv1.GrafanaDashboard{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, desired.Spec.ResyncPeriod, got.Spec.ResyncPeriod)
+	assert.NotEqual(t, "1", got.ResourceVersion, "spec change must trigger Update")
+}
+
+func TestHandleGrafanaDashboardUpdatesChangedLabels(t *testing.T) {
+	cr := testPlatformMonitoring()
+	desired, err := grafanaDashboard(cr, testDashboardAsset)
+	require.NoError(t, err)
+
+	stale := desired.DeepCopy()
+	stale.ResourceVersion = "1"
+	labels := stale.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels["test.example.com/stale"] = "true"
+	stale.SetLabels(labels)
+
+	r := newGrafanaDashboardTestReconciler(t, cr, stale)
+	require.NoError(t, r.handleGrafanaDashboard(testDashboardAsset, cr))
+
+	got := &grafv1.GrafanaDashboard{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, desired.GetLabels(), got.GetLabels())
+	assert.NotEqual(t, "1", got.ResourceVersion, "label change must trigger Update")
+}


### PR DESCRIPTION
## Summary
- Skip identical `GrafanaDashboard` Updates in `handleGrafanaDashboard` by comparing Spec and labels with `reflect.DeepEqual` before `UpdateResource` (same pattern as Grafana/Datasource handlers).
- Stops monitoring-operator from rewriting large dashboard CRs on every PlatformMonitoring reconcile (~60s), which was a major idle APIServer write source for #447.
- Adds unit tests for create, no-op skip, Spec change, and label change.

## Test plan
- [x] `go test ./controllers/grafana-operator/ -run TestHandleGrafanaDashboard`
- [x] Kind idle re-check with fixed binary: GrafanaDashboard Update count ≈ 0 while VM leases continue
- [x] One Spec drift then idle: 1 corrective Update, then 0 further Updates for that dashboard

Closes #447

Made with [Cursor](https://cursor.com)