### PR TITLE
fix(controller): preserve stable PlatformMonitoring status

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -125,6 +125,7 @@ gradlew         text eol=lf
 /charts/qubership-monitoring-operator/crds/** linguist-generated=true
 /charts/qubership-monitoring-operator/charts/*/crds/** linguist-generated=true
 /charts/qubership-monitoring-crds/crds/** linguist-generated=true
+/docs/api/platform-monitoring.md linguist-generated=true
 
 # Note: .db, .p, and .pkl files are associated
 # with the python modules ``pickle``, ``dbm.*``,

--- a/.github/super-linter.env
+++ b/.github/super-linter.env
@@ -43,8 +43,10 @@ VALIDATE_VUE=false
 # Disable rest of linters
 VALIDATE_SPELL_CODESPELL=false
 
-# Exclude generated agent-package troubleshooting assets: they follow the
-# troubleshooting-skill format contract (operator-facing terms like `regex`/`curl`,
-# case-scoped headings), not the repo's markdown/terminology rules.
+# Exclude generated documentation that is not authored under the repository's
+# markdown and terminology rules. Agent-package troubleshooting assets follow
+# the troubleshooting-skill format contract (operator-facing terms like
+# `regex`/`curl` and case-scoped headings). The PlatformMonitoring API reference
+# is generated from Go API types.
 # docs/troubleshooting.md is a symlink into that package.
-FILTER_REGEX_EXCLUDE=(agent-packages/.*|docs/troubleshooting(\.superseded)?\.md)
+FILTER_REGEX_EXCLUDE=(agent-packages/.*|docs/api/platform-monitoring\.md|docs/troubleshooting(\.superseded)?\.md)

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,6 @@ generate: controller-gen yq
 
 .PHONY: generate-all
 generate-all:
-	$(MAKE) generate
 	$(MAKE) update-operators-crds
 	$(MAKE) update-crds
 
@@ -347,9 +346,8 @@ test-crd-compaction: yq
 
 # Run document generation
 .PHONY: docs
-docs:
+docs: update-crds
 	@echo "=> 'make docs' is deprecated; use 'make update-crds' instead."
-	$(MAKE) update-crds
 
 ##########################
 # Update CRDs Helm chart #
@@ -357,7 +355,7 @@ docs:
 
 # Copy CRDs from canonical chart directories to the qubership-monitoring-crds Helm chart
 .PHONY: update-crds
-update-crds:
+update-crds: generate
 	echo "=> Update CRDs in dedicated Helm chart ..."
 	rm -f $(CRDS_HELM_CRDS_FOLDER)/crds/*.yaml $(CRDS_HELM_CRDS_FOLDER)/crds/*.yml
 	cp $(MON_CRD_FOLDER)/* $(CRDS_HELM_CRDS_FOLDER)/crds/
@@ -454,7 +452,7 @@ build-site: prepare-site-directory install-site-dependencies
 
 # Run archives with helm chart and crds creation
 .PHONY: archives
-archives: cleanup prepare-charts archive-helm-chart archive-crds
+archives: archive-helm-chart archive-crds
 
 # Remove build dir
 .PHONY: cleanup
@@ -463,7 +461,7 @@ cleanup:
 
 # Copy Helm charts to the /helm directory because the builder expect it in this dir
 .PHONY: prepare-charts
-prepare-charts:
+prepare-charts: cleanup
 	echo "=> Copy Helm charts to contract directory for build ..."
 	mkdir -p $(OUTPUT_DIR)
 
@@ -472,7 +470,7 @@ prepare-charts:
 
 # Archive Helm chart separately from application manifest
 .PHONY: archive-helm-chart
-archive-helm-chart:
+archive-helm-chart: prepare-charts update-crds
 	echo "=> Archive Helm charts ..."
 
 	# Navigate to dir to avoid unnecessary directories in result archive
@@ -481,7 +479,7 @@ archive-helm-chart:
 
 # Archive CRDs separately from helm chart
 .PHONY: archive-crds
-archive-crds:
+archive-crds: prepare-charts update-crds
 	echo "=> Archive CRDs ..."
 	# Copy documentation how to apply CRDS
 	cp docs/user-guides/manual-create-crds.md "${BUILD_DIR}"/_crds/README.md

--- a/api/v1/platformmonitoring_types.go
+++ b/api/v1/platformmonitoring_types.go
@@ -1731,6 +1731,9 @@ type PlatformMonitoringCondition struct {
 // PlatformMonitoringStatus defines the observed state of PlatformMonitoring
 type PlatformMonitoringStatus struct {
 	Conditions []PlatformMonitoringCondition `json:"conditions"`
+	// ObservedGeneration is the latest PlatformMonitoring generation that reached a terminal reconciliation result.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 }

--- a/api/v1/platformmonitoring_types_test.go
+++ b/api/v1/platformmonitoring_types_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,6 +33,15 @@ func TestPlatformMonitoringCRDManifest(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.NotNil(t, cr, "Custom resource manifest should not be empty")
+}
+
+func TestPlatformMonitoringStatusObservedGenerationJSON(t *testing.T) {
+	status := PlatformMonitoringStatus{ObservedGeneration: 7}
+
+	data, err := json.Marshal(status)
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"conditions":null,"observedGeneration":7}`, string(data))
 }
 
 func TestPlatformMonitoringAlertmanagerConfigCompatibility(t *testing.T) {

--- a/charts/qubership-monitoring-crds/crds/monitoring.netcracker.com_platformmonitorings.yaml
+++ b/charts/qubership-monitoring-crds/crds/monitoring.netcracker.com_platformmonitorings.yaml
@@ -26410,6 +26410,9 @@ spec:
                       - type
                     type: object
                   type: array
+                observedGeneration:
+                  format: int64
+                  type: integer
               required:
                 - conditions
               type: object

--- a/charts/qubership-monitoring-operator/crds/monitoring.netcracker.com_platformmonitorings.yaml
+++ b/charts/qubership-monitoring-operator/crds/monitoring.netcracker.com_platformmonitorings.yaml
@@ -26410,6 +26410,9 @@ spec:
                       - type
                     type: object
                   type: array
+                observedGeneration:
+                  format: int64
+                  type: integer
               required:
                 - conditions
               type: object

--- a/controllers/platformmonitoring_controller.go
+++ b/controllers/platformmonitoring_controller.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/victoriametrics/vmuser"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -105,11 +106,22 @@ func (r *PlatformMonitoringReconciler) Reconcile(context context.Context, reques
 	}
 	managedPrometheusEnabled := managedPrometheusExplicitlyEnabled(customResourceInstance)
 	customResourceInstance.FillEmptyWithDefaults()
-	r.syncPrometheusDeprecationCondition(customResourceInstance, managedPrometheusEnabled)
+	rInterval, intervalErr := strconv.ParseInt(utils.GetEnvWithDefaultValue("RECONCILIATION_INTERVAL"), 10, 64)
 
 	r.Log.Info("Reconciliation started")
-	if err = r.updateStatus(customResourceInstance, "In progress", "False", "ReconcileCycleStatus", "Monitoring service reconcile cycle in progress"); err != nil {
-		r.Log.Error(err, "Error while update status")
+	_, cycleCondition := r.getCondition(customResourceInstance, "ReconcileCycleStatus")
+	publishProgress := cycleCondition == nil ||
+		customResourceInstance.Generation != customResourceInstance.Status.ObservedGeneration ||
+		intervalErr != nil
+	if publishProgress {
+		r.syncPrometheusDeprecationCondition(customResourceInstance, managedPrometheusEnabled)
+		if err = r.updateStatus(customResourceInstance, "In progress", "False", "ReconcileCycleStatus", "Monitoring service reconcile cycle in progress"); err != nil {
+			r.Log.Error(err, "Error while update status")
+		}
+	}
+	statusBeforeReconcile := customResourceInstance.Status.DeepCopy()
+	if !publishProgress {
+		r.syncPrometheusDeprecationCondition(customResourceInstance, managedPrometheusEnabled)
 	}
 
 	// Prometheus Operator should create first because it should create CRDs:
@@ -291,18 +303,20 @@ func (r *PlatformMonitoringReconciler) Reconcile(context context.Context, reques
 		r.removeStatus(customResourceInstance, "ReconcilePushgatewayStatus")
 	}
 
-	rInterval, err := strconv.ParseInt(utils.GetEnvWithDefaultValue("RECONCILIATION_INTERVAL"), 10, 64)
-	if err != nil {
-		return reconcile.Result{}, err
+	if intervalErr != nil {
+		return reconcile.Result{}, intervalErr
 	}
 
 	failedStatus := hasFailedComponentCondition(customResourceInstance.Status.Conditions)
 
 	if failedStatus {
 		r.prepareStatusForUpdate(customResourceInstance, "Failed", "False", "ReconcileCycleStatus", "Monitoring service reconcile cycle failed")
+		customResourceInstance.Status.ObservedGeneration = customResourceInstance.Generation
 
-		if err = r.Client.Status().Update(context, customResourceInstance); err != nil {
-			r.Log.Error(err, "Update status failed.")
+		if !apiequality.Semantic.DeepEqual(statusBeforeReconcile, &customResourceInstance.Status) {
+			if err = r.Client.Status().Update(context, customResourceInstance); err != nil {
+				r.Log.Error(err, "Update status failed.")
+			}
 		}
 
 		r.Log.Info("Reconciliation failed. Run reconciliation again.")
@@ -310,10 +324,13 @@ func (r *PlatformMonitoringReconciler) Reconcile(context context.Context, reques
 	}
 
 	r.prepareStatusForUpdate(customResourceInstance, "Successful", "True", "ReconcileCycleStatus", "Monitoring service reconcile cycle succeeded")
+	customResourceInstance.Status.ObservedGeneration = customResourceInstance.Generation
 	r.Log.Info("Reconciliation finished successful, next reconciliation after " + utils.GetEnvWithDefaultValue("RECONCILIATION_INTERVAL") + " seconds")
 
-	if err = r.Client.Status().Update(context, customResourceInstance); err != nil {
-		r.Log.Error(err, "Update status failed")
+	if !apiequality.Semantic.DeepEqual(statusBeforeReconcile, &customResourceInstance.Status) {
+		if err = r.Client.Status().Update(context, customResourceInstance); err != nil {
+			r.Log.Error(err, "Update status failed")
+		}
 	}
 
 	return reconcile.Result{RequeueAfter: time.Duration(rInterval) * time.Second}, nil

--- a/controllers/platformmonitoring_controller.go
+++ b/controllers/platformmonitoring_controller.go
@@ -296,15 +296,7 @@ func (r *PlatformMonitoringReconciler) Reconcile(context context.Context, reques
 		return reconcile.Result{}, err
 	}
 
-	status := customResourceInstance.Status.Conditions
-	failedStatus := false
-
-	for i := range status {
-		if status[i].Type == "Failed" {
-			failedStatus = true
-			break
-		}
-	}
+	failedStatus := hasFailedComponentCondition(customResourceInstance.Status.Conditions)
 
 	if failedStatus {
 		r.prepareStatusForUpdate(customResourceInstance, "Failed", "False", "ReconcileCycleStatus", "Monitoring service reconcile cycle failed")
@@ -381,6 +373,15 @@ func ignoreDeletionPredicate() predicate.Predicate {
 			return !e.DeleteStateUnknown
 		},
 	}
+}
+
+func hasFailedComponentCondition(conditions []qubershiporgv1.PlatformMonitoringCondition) bool {
+	for i := range conditions {
+		if conditions[i].Type == "Failed" && conditions[i].Reason != "ReconcileCycleStatus" {
+			return true
+		}
+	}
+	return false
 }
 
 // getCondition retrieves condition of custom resource instance by given reason.
@@ -460,22 +461,31 @@ func (r *PlatformMonitoringReconciler) updateStatus(customResourceInstance *qube
 
 // prepareStatusForUpdate checks if old condition with same reason exist and change it on the new condition
 func (r *PlatformMonitoringReconciler) prepareStatusForUpdate(customResourceInstance *qubershiporgv1.PlatformMonitoring, statusType string, status string, reason string, message string) bool {
-	// get status timestamp
-	transitionTime := metav1.Now()
+	idx, oldCondition := r.getCondition(customResourceInstance, reason)
+
+	if oldCondition == nil {
+		newCondition := qubershiporgv1.PlatformMonitoringCondition{
+			Type:               statusType,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: metav1.Now().String(),
+		}
+		customResourceInstance.Status.Conditions = append(customResourceInstance.Status.Conditions, newCondition)
+		return true
+	}
+
+	transitionTime := oldCondition.LastTransitionTime
+	if oldCondition.Type != statusType || oldCondition.Status != status || transitionTime == "" {
+		transitionTime = metav1.Now().String()
+	}
 	newCondition := qubershiporgv1.PlatformMonitoringCondition{
 		Type:               statusType,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
-		LastTransitionTime: transitionTime.String(),
+		LastTransitionTime: transitionTime,
 	}
-	idx, oldCondition := r.getCondition(customResourceInstance, newCondition.Reason)
-
-	if oldCondition == nil {
-		customResourceInstance.Status.Conditions = append(customResourceInstance.Status.Conditions, newCondition)
-		return true
-	}
-
 	isEqual := newCondition.Type == oldCondition.Type &&
 		newCondition.Status == oldCondition.Status &&
 		newCondition.Reason == oldCondition.Reason &&

--- a/controllers/platformmonitoring_controller_test.go
+++ b/controllers/platformmonitoring_controller_test.go
@@ -3,23 +3,37 @@ package controllers
 import (
 	"context"
 	"testing"
+	"time"
 
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	vmetricsv1b1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/go-logr/logr"
+	grafv1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	v1beta1ext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestRequestsForGrafanaExtraVars(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, monv1.AddToScheme(scheme))
-	reconciler := &PlatformMonitoringReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+	reconciler := &PlatformMonitoringReconciler{Client: clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(
 		&monv1.PlatformMonitoring{
 			ObjectMeta: metav1.ObjectMeta{Name: "custom", Namespace: "monitoring"},
 			Spec: monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{
@@ -40,7 +54,7 @@ func TestRequestsForGrafanaExtraVars(t *testing.T) {
 
 func TestRequestsForGrafanaExtraVarsReturnsNoRequestsWhenListFails(t *testing.T) {
 	reconciler := &PlatformMonitoringReconciler{
-		Client: fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
+		Client: clientfake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build(),
 		Log:    logr.Discard(),
 	}
 
@@ -56,6 +70,38 @@ func TestGrafanaExtraVarsResourcePredicates(t *testing.T) {
 	assert.False(t, isGrafanaExtraVarsConfigMap(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars-secret"}}))
 	assert.True(t, isGrafanaExtraVarsSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars-secret"}}))
 	assert.False(t, isGrafanaExtraVarsSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars"}}))
+}
+
+type countingStatusWriter struct {
+	client.SubResourceWriter
+	updates int
+}
+
+func (w *countingStatusWriter) Update(
+	ctx context.Context,
+	obj client.Object,
+	opts ...client.SubResourceUpdateOption,
+) error {
+	w.updates++
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
+type statusCountingClient struct {
+	client.Client
+	statusWriter *countingStatusWriter
+}
+
+func newStatusCountingClient(delegate client.Client) *statusCountingClient {
+	return &statusCountingClient{
+		Client: delegate,
+		statusWriter: &countingStatusWriter{
+			SubResourceWriter: delegate.Status(),
+		},
+	}
+}
+
+func (c *statusCountingClient) Status() client.SubResourceWriter {
+	return c.statusWriter
 }
 
 func TestPrepareStatusForUpdatePreservesTransitionTime(t *testing.T) {
@@ -215,4 +261,201 @@ func TestHasFailedComponentConditionIgnoresCycleCondition(t *testing.T) {
 			assert.Equal(t, tt.want, hasFailedComponentCondition(tt.conditions))
 		})
 	}
+}
+
+func TestReconcileStatusWrites(t *testing.T) {
+	const transitionTime = "2026-08-11 12:00:00 +0000 UTC"
+
+	tests := []struct {
+		name               string
+		generation         int64
+		observedGeneration int64
+		wantUpdates        int
+	}{
+		{
+			name:               "idle observed generation",
+			generation:         1,
+			observedGeneration: 1,
+			wantUpdates:        0,
+		},
+		{
+			name:               "new generation",
+			generation:         2,
+			observedGeneration: 1,
+			wantUpdates:        2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &monv1.PlatformMonitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "monitoring",
+					Namespace:  "monitoring",
+					Generation: tt.generation,
+				},
+				Status: monv1.PlatformMonitoringStatus{
+					ObservedGeneration: tt.observedGeneration,
+					Conditions: []monv1.PlatformMonitoringCondition{{
+						Type:               "Successful",
+						Status:             "True",
+						Reason:             "ReconcileCycleStatus",
+						Message:            "Monitoring service reconcile cycle succeeded",
+						LastTransitionTime: transitionTime,
+					}},
+				},
+			}
+			reconciler, countingClient := newStatusTestReconciler(t, resource)
+
+			result, err := reconciler.Reconcile(
+				context.Background(),
+				ctrl.Request{NamespacedName: types.NamespacedName{Name: resource.Name, Namespace: resource.Namespace}},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, 60*time.Second, result.RequeueAfter)
+			assert.Equal(t, tt.wantUpdates, countingClient.statusWriter.updates)
+
+			stored := &monv1.PlatformMonitoring{}
+			require.NoError(t, countingClient.Get(
+				context.Background(),
+				client.ObjectKeyFromObject(resource),
+				stored,
+			))
+			assert.Equal(t, tt.generation, stored.Status.ObservedGeneration)
+			assert.Equal(t, "Successful", stored.Status.Conditions[0].Type)
+			if tt.wantUpdates == 0 {
+				assert.Equal(t, transitionTime, stored.Status.Conditions[0].LastTransitionTime)
+			}
+		})
+	}
+}
+
+func TestReconcileStatusRecoversFromPriorFailure(t *testing.T) {
+	resource := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "monitoring",
+			Namespace:  "monitoring",
+			Generation: 1,
+		},
+		Status: monv1.PlatformMonitoringStatus{
+			ObservedGeneration: 1,
+			Conditions: []monv1.PlatformMonitoringCondition{
+				{
+					Type:               "Failed",
+					Status:             "False",
+					Reason:             "ReconcilePrometheusStatus",
+					Message:            "Prometheus reconcile cycle failed",
+					LastTransitionTime: "2026-08-11 12:00:00 +0000 UTC",
+				},
+				{
+					Type:               "Failed",
+					Status:             "False",
+					Reason:             "ReconcileCycleStatus",
+					Message:            "Monitoring service reconcile cycle failed",
+					LastTransitionTime: "2026-08-11 12:00:00 +0000 UTC",
+				},
+			},
+		},
+	}
+	reconciler, countingClient := newStatusTestReconciler(t, resource)
+
+	result, err := reconciler.Reconcile(
+		context.Background(),
+		ctrl.Request{NamespacedName: client.ObjectKeyFromObject(resource)},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 60*time.Second, result.RequeueAfter)
+	assert.Equal(t, 1, countingClient.statusWriter.updates)
+
+	stored := &monv1.PlatformMonitoring{}
+	require.NoError(t, countingClient.Get(context.Background(), client.ObjectKeyFromObject(resource), stored))
+	require.Len(t, stored.Status.Conditions, 1)
+	assert.Equal(t, "ReconcileCycleStatus", stored.Status.Conditions[0].Reason)
+	assert.Equal(t, "Successful", stored.Status.Conditions[0].Type)
+	assert.Equal(t, "True", stored.Status.Conditions[0].Status)
+}
+
+func TestReconcileInvalidIntervalRunsComponents(t *testing.T) {
+	resource := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "monitoring",
+			Namespace:  "monitoring",
+			Generation: 1,
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			KubernetesMonitors: map[string]monv1.Monitor{
+				"apiserverServiceMonitor": {Install: ptr.To(false)},
+			},
+		},
+		Status: monv1.PlatformMonitoringStatus{
+			ObservedGeneration: 1,
+			Conditions: []monv1.PlatformMonitoringCondition{{
+				Type:               "Successful",
+				Status:             "True",
+				Reason:             "ReconcileCycleStatus",
+				Message:            "Monitoring service reconcile cycle succeeded",
+				LastTransitionTime: "2026-08-11 12:00:00 +0000 UTC",
+			}},
+		},
+	}
+	staleServiceMonitor := &promv1.ServiceMonitor{ObjectMeta: metav1.ObjectMeta{
+		Name:      "monitoring-kube-apiserver-service-monitor",
+		Namespace: "monitoring",
+	}}
+	reconciler, countingClient := newStatusTestReconciler(t, resource, staleServiceMonitor)
+	t.Setenv("RECONCILIATION_INTERVAL", "invalid")
+
+	_, err := reconciler.Reconcile(
+		context.Background(),
+		ctrl.Request{NamespacedName: client.ObjectKeyFromObject(resource)},
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid syntax")
+	assert.Equal(t, 1, countingClient.statusWriter.updates)
+
+	deleted := &promv1.ServiceMonitor{}
+	err = countingClient.Get(context.Background(), client.ObjectKeyFromObject(staleServiceMonitor), deleted)
+	assert.True(t, apierrors.IsNotFound(err))
+
+	stored := &monv1.PlatformMonitoring{}
+	require.NoError(t, countingClient.Get(context.Background(), client.ObjectKeyFromObject(resource), stored))
+	assert.Equal(t, int64(1), stored.Status.ObservedGeneration)
+	require.Len(t, stored.Status.Conditions, 1)
+	assert.Equal(t, "In progress", stored.Status.Conditions[0].Type)
+}
+
+func newStatusTestReconciler(
+	t *testing.T,
+	objects ...client.Object,
+) (*PlatformMonitoringReconciler, *statusCountingClient) {
+	t.Helper()
+	t.Setenv("LOG_LEVEL", "error")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	require.NoError(t, grafv1.AddToScheme(scheme))
+	require.NoError(t, vmetricsv1b1.AddToScheme(scheme))
+	require.NoError(t, v1beta1ext.AddToScheme(scheme))
+	baseClient := clientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&monv1.PlatformMonitoring{}).
+		WithObjects(objects...).
+		Build()
+	countingClient := newStatusCountingClient(baseClient)
+
+	return &PlatformMonitoringReconciler{
+		Client: countingClient,
+		Log:    logr.Discard(),
+		Scheme: scheme,
+		Config: &rest.Config{},
+		DiscoveryClient: &fake.FakeDiscovery{
+			Fake:               &k8stesting.Fake{},
+			FakedServerVersion: &version.Info{Major: "1", Minor: "30"},
+		},
+	}, countingClient
 }

--- a/controllers/platformmonitoring_controller_test.go
+++ b/controllers/platformmonitoring_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	qubershiporgv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,15 +18,15 @@ import (
 
 func TestRequestsForGrafanaExtraVars(t *testing.T) {
 	scheme := runtime.NewScheme()
-	require.NoError(t, qubershiporgv1.AddToScheme(scheme))
+	require.NoError(t, monv1.AddToScheme(scheme))
 	reconciler := &PlatformMonitoringReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-		&qubershiporgv1.PlatformMonitoring{
+		&monv1.PlatformMonitoring{
 			ObjectMeta: metav1.ObjectMeta{Name: "custom", Namespace: "monitoring"},
-			Spec: qubershiporgv1.PlatformMonitoringSpec{Grafana: &qubershiporgv1.Grafana{
+			Spec: monv1.PlatformMonitoringSpec{Grafana: &monv1.Grafana{
 				Namespace: "grafana",
 			}},
 		},
-		&qubershiporgv1.PlatformMonitoring{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "other"}},
+		&monv1.PlatformMonitoring{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "other"}},
 	).Build()}
 
 	requests := reconciler.requestsForPlatformMonitorings(context.Background(), &corev1.ConfigMap{
@@ -56,4 +56,163 @@ func TestGrafanaExtraVarsResourcePredicates(t *testing.T) {
 	assert.False(t, isGrafanaExtraVarsConfigMap(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars-secret"}}))
 	assert.True(t, isGrafanaExtraVarsSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars-secret"}}))
 	assert.False(t, isGrafanaExtraVarsSecret(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "grafana-extra-vars"}}))
+}
+
+func TestPrepareStatusForUpdatePreservesTransitionTime(t *testing.T) {
+	const transitionTime = "2026-08-11 12:00:00 +0000 UTC"
+
+	tests := []struct {
+		name        string
+		oldMessage  string
+		newMessage  string
+		wantChanged bool
+	}{
+		{
+			name:        "unchanged condition",
+			oldMessage:  "Monitoring service reconcile cycle succeeded",
+			newMessage:  "Monitoring service reconcile cycle succeeded",
+			wantChanged: false,
+		},
+		{
+			name:        "message-only update",
+			oldMessage:  "Old diagnostic details",
+			newMessage:  "New diagnostic details",
+			wantChanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &monv1.PlatformMonitoring{
+				Status: monv1.PlatformMonitoringStatus{
+					Conditions: []monv1.PlatformMonitoringCondition{{
+						Type:               "Successful",
+						Status:             "True",
+						Reason:             "ReconcileCycleStatus",
+						Message:            tt.oldMessage,
+						LastTransitionTime: transitionTime,
+					}},
+				},
+			}
+			reconciler := &PlatformMonitoringReconciler{}
+
+			changed := reconciler.prepareStatusForUpdate(
+				resource,
+				"Successful",
+				"True",
+				"ReconcileCycleStatus",
+				tt.newMessage,
+			)
+
+			assert.Equal(t, tt.wantChanged, changed)
+			assert.Equal(t, tt.newMessage, resource.Status.Conditions[0].Message)
+			assert.Equal(t, transitionTime, resource.Status.Conditions[0].LastTransitionTime)
+		})
+	}
+}
+
+func TestPrepareStatusForUpdateAdvancesTransitionTime(t *testing.T) {
+	const transitionTime = "2026-08-11 12:00:00 +0000 UTC"
+
+	tests := []struct {
+		name      string
+		oldType   string
+		newType   string
+		oldStatus string
+		newStatus string
+		oldTime   string
+	}{
+		{
+			name:      "type transition",
+			oldType:   "Successful",
+			newType:   "Failed",
+			oldStatus: "True",
+			newStatus: "True",
+			oldTime:   transitionTime,
+		},
+		{
+			name:      "status transition",
+			oldType:   "Successful",
+			newType:   "Successful",
+			oldStatus: "False",
+			newStatus: "True",
+			oldTime:   transitionTime,
+		},
+		{
+			name:      "missing transition time",
+			oldType:   "Successful",
+			newType:   "Successful",
+			oldStatus: "True",
+			newStatus: "True",
+			oldTime:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &monv1.PlatformMonitoring{
+				Status: monv1.PlatformMonitoringStatus{
+					Conditions: []monv1.PlatformMonitoringCondition{{
+						Type:               tt.oldType,
+						Status:             tt.oldStatus,
+						Reason:             "ReconcileCycleStatus",
+						Message:            "Monitoring service reconcile cycle completed",
+						LastTransitionTime: tt.oldTime,
+					}},
+				},
+			}
+			reconciler := &PlatformMonitoringReconciler{}
+
+			changed := reconciler.prepareStatusForUpdate(
+				resource,
+				tt.newType,
+				tt.newStatus,
+				"ReconcileCycleStatus",
+				"Monitoring service reconcile cycle completed",
+			)
+
+			assert.True(t, changed)
+			assert.NotEmpty(t, resource.Status.Conditions[0].LastTransitionTime)
+			assert.NotEqual(t, tt.oldTime, resource.Status.Conditions[0].LastTransitionTime)
+		})
+	}
+}
+
+func TestHasFailedComponentConditionIgnoresCycleCondition(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []monv1.PlatformMonitoringCondition
+		want       bool
+	}{
+		{
+			name: "aggregate failure only",
+			conditions: []monv1.PlatformMonitoringCondition{{
+				Type:   "Failed",
+				Reason: "ReconcileCycleStatus",
+			}},
+			want: false,
+		},
+		{
+			name: "component failure",
+			conditions: []monv1.PlatformMonitoringCondition{{
+				Type:   "Failed",
+				Reason: "ReconcilePrometheusStatus",
+			}},
+			want: true,
+		},
+		{
+			name: "successful component condition",
+			conditions: []monv1.PlatformMonitoringCondition{{
+				Type:   "Successful",
+				Reason: "ReconcilePrometheusStatus",
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasFailedComponentCondition(tt.conditions))
+		})
+	}
 }

--- a/docs/api/platform-monitoring.md
+++ b/docs/api/platform-monitoring.md
@@ -316,6 +316,7 @@ PlatformMonitoringStatus defines the observed state of PlatformMonitoring.
 | Field | Description | Scheme | Required |
 | --- | --- | --- | --- |
 | conditions | | \[\][PlatformMonitoringCondition](#platformmonitoringcondition) | true |
+| observedGeneration | ObservedGeneration is the latest PlatformMonitoring generation that reached a terminal reconciliation result. | int64 | false |
 
 
 
@@ -667,4 +668,3 @@ VmOperator defines the desired state for some part of the victoriametrics-operat
 | volumeMounts | VolumeMounts allows configuration of additional VolumeMounts on the output deploy definition. VolumeMounts specified will be appended to other VolumeMounts in the alertmanager container, that are generated as a result of StorageSpec objects. | []v1.VolumeMount | false |
 | extraArgs | ExtraArgs that will be passed to  VMAlertmanager pod for example log.level: debug | map[string]string | false |
 | extraEnvs | ExtraEnvs that will be added to VMAlertmanager pod | []v1.EnvVar | false |
-

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -130,6 +130,16 @@ For detailed information about components, see [Components](components/).
 !!! note "CRD Management"
     Helm does not update or remove CRDs. For upgrades involving CRD changes, manual updates are required.
 
+Apply the complete CRD bundle, or synchronize the dedicated
+`qubership-monitoring-crds` chart, before upgrading the monitoring operator.
+Verify that the installed PlatformMonitoring CRD contains
+`status.observedGeneration`, then upgrade the operator chart. An older
+structural schema prunes this status field and prevents the controller from
+identifying an already observed resource generation.
+
+For Argo CD deployments, complete the CRD application synchronization before
+synchronizing the monitoring operator application.
+
 ## Post-Installation Verification
 
 After installing the monitoring operator, verify that all components are running correctly:

--- a/test/envtests/platformmonitoring_status_test.go
+++ b/test/envtests/platformmonitoring_status_test.go
@@ -1,0 +1,78 @@
+//go:build envtest
+
+package envtests
+
+import (
+	"context"
+	"os"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("PlatformMonitoring status stability", func() {
+	It("preserves status during an idle reconciliation", func() {
+		ctx := context.Background()
+		const namespaceName = "status-stability"
+
+		originalInterval, intervalWasSet := os.LookupEnv("RECONCILIATION_INTERVAL")
+		Expect(os.Setenv("RECONCILIATION_INTERVAL", "60")).To(Succeed())
+		DeferCleanup(func() {
+			if intervalWasSet {
+				Expect(os.Setenv("RECONCILIATION_INTERVAL", originalInterval)).To(Succeed())
+				return
+			}
+			Expect(os.Unsetenv("RECONCILIATION_INTERVAL")).To(Succeed())
+		})
+
+		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, namespace))).To(Succeed())
+		})
+
+		resource := &monv1.PlatformMonitoring{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "status-stability",
+				Namespace: namespaceName,
+			},
+		}
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		reconciler := &controllers.PlatformMonitoringReconciler{
+			Client:          k8sClient,
+			Scheme:          clientgoscheme.Scheme,
+			Config:          cfg,
+			DiscoveryClient: discoveryClient,
+		}
+		request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(resource)}
+
+		_, err := reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+
+		first := &monv1.PlatformMonitoring{}
+		Expect(k8sClient.Get(ctx, request.NamespacedName, first)).To(Succeed())
+		Expect(first.Status.ObservedGeneration).To(Equal(first.Generation))
+		Expect(first.Status.Conditions).To(HaveLen(1))
+		Expect(first.Status.Conditions[0].Type).To(Equal("Successful"))
+
+		firstResourceVersion := first.ResourceVersion
+		firstConditions := append([]monv1.PlatformMonitoringCondition(nil), first.Status.Conditions...)
+
+		_, err = reconciler.Reconcile(ctx, request)
+		Expect(err).NotTo(HaveOccurred())
+
+		second := &monv1.PlatformMonitoring{}
+		Expect(k8sClient.Get(ctx, request.NamespacedName, second)).To(Succeed())
+		Expect(second.ResourceVersion).To(Equal(firstResourceVersion))
+		Expect(second.Status.ObservedGeneration).To(Equal(first.Status.ObservedGeneration))
+		Expect(second.Status.Conditions).To(Equal(firstConditions))
+	})
+})


### PR DESCRIPTION
Closes #469.

## Scope

- Preserve `lastTransitionTime` when a PlatformMonitoring condition is unchanged or only its message changes.
- Avoid transient `In progress` and terminal status writes during an idle reconciliation of an already observed generation.
- Track the last terminal generation in `status.observedGeneration` so spec updates still publish reconciliation progress.
- Exclude the aggregate cycle condition from component failure detection, allowing a previously failed resource to recover.
- Keep component reconciliation running when `RECONCILIATION_INTERVAL` is invalid without publishing a misleading terminal result.
- Synchronize both PlatformMonitoring CRD copies and document the required CRD-first Helm and Argo CD upgrade order.
- Make CRD generation and archive dependencies deterministic when archive targets run in parallel.

No Helm values, RBAC rules, component manifests, or workload defaults are changed.

## Compatibility

`status.observedGeneration` is an additive status field. The new CRD must be applied before the operator upgrade because an older structural schema prunes the field and prevents idle reconciliation detection.

## Verification

- Unit tests, including status write counts, transition semantics, invalid interval handling, and failed-cycle recovery.
- Envtest with a real API server, including CRD schema persistence and a stable `resourceVersion` on the second idle reconciliation.
- Generated-file drift and canonical/dedicated CRD consistency checks.
- Helm lint and privileged/non-privileged render checks.
- Parallel CRD archive generation and archive-content verification.
- Kind CRD-first operator upgrade: the resource reached `Successful`, persisted `observedGeneration=1`, and kept the same `resourceVersion` and transition time across multiple periodic reconciliation intervals.
