### PR TITLE
fix(renovate): keep operator updates synchronized

### DIFF
--- a/.github/scripts/test-renovate-operator-groups.mjs
+++ b/.github/scripts/test-renovate-operator-groups.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const [logFile] = process.argv.slice(2);
+assert.ok(logFile, 'Usage: node test-renovate-operator-groups.mjs <renovate-debug-log>');
+
+const renovateConfig = JSON.parse(readFileSync('renovate.json', 'utf8'));
+const records = readFileSync(logFile, 'utf8')
+  .split('\n')
+  .flatMap((line) => {
+    try {
+      return [JSON.parse(line)];
+    } catch {
+      return [];
+    }
+  });
+const extraction = records.findLast((record) => record.msg === 'Extracted dependencies');
+assert.ok(extraction?.packageFiles, 'Renovate did not emit an Extracted dependencies record');
+
+const dependencies = Object.values(extraction.packageFiles)
+  .flat()
+  .flatMap((packageFile) => packageFile.deps.map((dependency) => ({ ...dependency, packageFile: packageFile.packageFile })));
+
+function normalizeVersion(version) {
+  return version.replace(/^config-reloader-v|^v/, '');
+}
+
+function assertGroup(groupName, groupDependencies, packageNames, expectedFiles) {
+  const rule = renovateConfig.packageRules.find((candidate) => candidate.groupName === groupName);
+  assert.ok(rule, `${groupName}: package rule is missing`);
+  assert.equal(
+    rule.minimumGroupSize,
+    groupDependencies.length,
+    `${groupName}: minimumGroupSize must cover every extracted reference`,
+  );
+  assert.deepEqual(rule.matchPackageNames, packageNames, `${groupName}: package matchers changed without updating this contract`);
+  assert.deepEqual(
+    groupDependencies.map(({ packageFile }) => packageFile).sort(),
+    expectedFiles.sort(),
+    `${groupName}: extracted files changed without updating this contract`,
+  );
+  assert.equal(
+    new Set(groupDependencies.map(({ currentValue }) => normalizeVersion(currentValue))).size,
+    1,
+    `${groupName}: extracted references use different versions`,
+  );
+}
+
+const prometheusDependencies = dependencies.filter(
+  ({ depName }) =>
+    depName === 'github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring' ||
+    depName === 'prometheus-operator/prometheus-operator',
+);
+
+assert.equal(prometheusDependencies.length, 4, 'Prometheus Operator: expected four extracted references');
+assert.equal(
+  prometheusDependencies.filter(({ datasource }) => datasource === 'github-releases').length,
+  3,
+  'Prometheus Operator: image and CRD-source references must use GitHub release timestamps',
+);
+const prometheusImageReferences = prometheusDependencies.filter(
+  ({ packageFile }) => packageFile === 'charts/qubership-monitoring-operator/templates/_images.tpl',
+);
+assert.equal(
+  prometheusImageReferences.filter(({ replaceString }) => replaceString.includes('prometheus-operator:v')).length,
+  1,
+  'Prometheus Operator: expected one operator image reference',
+);
+assert.equal(
+  prometheusImageReferences.filter(({ replaceString }) => replaceString.includes('prometheus-config-reloader:v')).length,
+  1,
+  'Prometheus Operator: expected one config-reloader image reference',
+);
+assertGroup(
+  'Prometheus Operator',
+  prometheusDependencies,
+  ['github.com/prometheus-operator/prometheus-operator{/,}**', 'prometheus-operator/prometheus-operator'],
+  [
+    'go.mod',
+    'Makefile',
+    'charts/qubership-monitoring-operator/templates/_images.tpl',
+    'charts/qubership-monitoring-operator/templates/_images.tpl',
+  ],
+);
+
+const victoriaMetricsDependencies = dependencies.filter(
+  ({ depName }) => depName === 'github.com/VictoriaMetrics/operator/api' || depName === 'VictoriaMetrics/operator',
+);
+
+assert.equal(victoriaMetricsDependencies.length, 9, 'VictoriaMetrics Operator: expected nine extracted references');
+assert.equal(
+  victoriaMetricsDependencies.filter(({ datasource }) => datasource === 'github-releases').length,
+  8,
+  'VictoriaMetrics Operator: image and CRD-source references must use GitHub release timestamps',
+);
+const victoriaMetricsTemplateReferences = victoriaMetricsDependencies.filter(
+  ({ packageFile }) => packageFile === 'charts/qubership-monitoring-operator/templates/_images.tpl',
+);
+assert.equal(
+  victoriaMetricsTemplateReferences.filter(({ replaceString }) => replaceString.includes('operator:v')).length,
+  1,
+  'VictoriaMetrics Operator: expected one operator image reference',
+);
+assert.equal(
+  victoriaMetricsTemplateReferences.filter(({ replaceString }) => replaceString.includes('operator:config-reloader-v')).length,
+  5,
+  'VictoriaMetrics Operator: expected five config-reloader image references',
+);
+assertGroup(
+  'VictoriaMetrics Operator',
+  victoriaMetricsDependencies,
+  ['github.com/VictoriaMetrics/operator{/,}**', 'VictoriaMetrics/operator'],
+  [
+    'go.mod',
+    'Makefile',
+    'charts/qubership-monitoring-operator/templates/_images.tpl',
+    'charts/qubership-monitoring-operator/templates/_images.tpl',
+    'charts/qubership-monitoring-operator/templates/_images.tpl',
+    'charts/qubership-monitoring-operator/templates/_images.tpl',
+    'charts/qubership-monitoring-operator/templates/_images.tpl',
+    'charts/qubership-monitoring-operator/templates/_images.tpl',
+    'controllers/victoriametrics/vmoperator/assets/deployment.yaml',
+  ],
+);
+
+console.log('Managed operator Renovate groups are complete and version-aligned.');

--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -3,12 +3,22 @@ name: Validate Renovate Config
 on:
   push:
     paths:
+      - .github/scripts/test-renovate-operator-groups.mjs
       - renovate.json
       - .github/workflows/renovate-config-lint.yaml
+      - Makefile
+      - charts/qubership-monitoring-operator/templates/_images.tpl
+      - controllers/victoriametrics/vmoperator/assets/deployment.yaml
+      - go.mod
   pull_request:
     paths:
+      - .github/scripts/test-renovate-operator-groups.mjs
       - renovate.json
       - .github/workflows/renovate-config-lint.yaml
+      - Makefile
+      - charts/qubership-monitoring-operator/templates/_images.tpl
+      - controllers/victoriametrics/vmoperator/assets/deployment.yaml
+      - go.mod
   schedule:
     - cron: "30 7 * * 1"
   workflow_dispatch: {}
@@ -86,6 +96,27 @@ jobs:
             echo "::error::Renovate preset resolution exited with code $renovate_status"
             exit "$renovate_status"
           fi
+
+      - name: Test managed operator groups
+        shell: bash
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          LOG_FORMAT: json
+          LOG_LEVEL: debug
+          RENOVATE_CONFIG: >-
+            {"includePaths":["Makefile","charts/qubership-monitoring-operator/templates/_images.tpl","controllers/victoriametrics/vmoperator/assets/deployment.yaml","go.mod"]}
+          RENOVATE_ENABLED_MANAGERS: custom.regex,gomod
+        run: |
+          set -euo pipefail
+          log_file="$(mktemp)"
+          trap 'rm -f "$log_file"' EXIT
+
+          if ! renovate --platform=local --dry-run=extract > "$log_file" 2>&1; then
+            cat "$log_file"
+            exit 1
+          fi
+
+          node .github/scripts/test-renovate-operator-groups.mjs "$log_file"
 
   lookup-renovate-dependencies:
     name: Look up Renovate dependencies

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ DOCKERFILE=cmd/operator/Dockerfile
 # `make update-prometheus-crds PROMETHEUS_OPERATOR_VERSION=0.92.1`)
 CRD_UPDATE_TOOL=tools/crd-update/crd-update.py
 PYTHON?=python3
-# renovate: datasource=docker depName=quay.io/prometheus-operator/prometheus-operator
+# renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator versioning=semver-coerced
 PROMETHEUS_OPERATOR_VERSION?=0.92.1
-# renovate: datasource=docker depName=victoriametrics/operator
+# renovate: datasource=github-releases depName=VictoriaMetrics/operator versioning=semver-coerced
 VICTORIAMETRICS_OPERATOR_VERSION?=0.73.1
 GRAFANA_OPERATOR_VERSION?=5.24.0
 LOCALBIN ?= $(CURDIR)/bin

--- a/charts/qubership-monitoring-operator/templates/_images.tpl
+++ b/charts/qubership-monitoring-operator/templates/_images.tpl
@@ -79,7 +79,7 @@ Image can be found from:
   {{- if .Values.prometheus.operator.image -}}
     {{- printf "%s" .Values.prometheus.operator.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=docker depName=quay.io/prometheus-operator/prometheus-operator */ -}}
+    {{- /* # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator versioning=semver-coerced */ -}}
     {{- print "quay.io/prometheus-operator/prometheus-operator:v0.92.1" -}}
   {{- end -}}
 {{- end -}}
@@ -94,7 +94,7 @@ Image can be found from:
   {{- if .Values.prometheus.configReloaderImage -}}
     {{- printf "%s" .Values.prometheus.configReloaderImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=docker depName=quay.io/prometheus-operator/prometheus-config-reloader */ -}}
+    {{- /* # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator versioning=semver-coerced */ -}}
     {{- print "quay.io/prometheus-operator/prometheus-config-reloader:v0.92.1" -}}
   {{- end -}}
 {{- end -}}
@@ -141,7 +141,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmOperator.image -}}
     {{- printf "%s" .Values.victoriametrics.vmOperator.image -}}
   {{- else -}}
-    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
+    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/operator versioning=semver-coerced */ -}}
     {{- print "docker.io/victoriametrics/operator:v0.73.1" -}}
   {{- end -}}
 {{- end -}}
@@ -156,7 +156,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmOperator.configReloaderImage -}}
     {{- printf "%s" .Values.victoriametrics.vmOperator.configReloaderImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
+    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/operator versioning=semver-coerced */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.73.1" -}}
   {{- end -}}
 {{- end -}}
@@ -186,7 +186,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAgent.configReloadImage -}}
     {{- printf "%s" .Values.victoriametrics.vmAgent.configReloadImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
+    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/operator versioning=semver-coerced */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.73.1" -}}
   {{- end -}}
 {{- end -}}
@@ -216,7 +216,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAlert.configReloadImage -}}
     {{- printf "%s" .Values.victoriametrics.vmAlert.configReloadImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
+    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/operator versioning=semver-coerced */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.73.1" -}}
   {{- end -}}
 {{- end -}}
@@ -246,7 +246,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAlertManager.configReloadImage -}}
     {{- printf "%s" .Values.victoriametrics.vmAlertManager.configReloadImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
+    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/operator versioning=semver-coerced */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.73.1" -}}
   {{- end -}}
 {{- end -}}
@@ -321,7 +321,7 @@ Image can be found from:
   {{- if .Values.victoriametrics.vmAuth.configReloadImage -}}
     {{- printf "%s" .Values.victoriametrics.vmAuth.configReloadImage -}}
   {{- else -}}
-    {{- /* # renovate: datasource=docker depName=victoriametrics/operator */ -}}
+    {{- /* # renovate: datasource=github-releases depName=VictoriaMetrics/operator versioning=semver-coerced */ -}}
     {{- print "docker.io/victoriametrics/operator:config-reloader-v0.73.1" -}}
   {{- end -}}
 {{- end -}}

--- a/renovate.json
+++ b/renovate.json
@@ -28,9 +28,12 @@
         "/^charts/qubership-monitoring-operator/templates/_images\\.tpl$/"
       ],
       "matchStrings": [
-        "\\{\\{-?[\\t ]*/\\*[\\t ]+#?[\\t ]*renovate: datasource=(?<datasource>docker) depName=(?<depName>victoriametrics/operator)[\\t ]*\\*/[\\t ]*-?\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{-?[\\t ]*print[\\t ]+\\\"[^\\\"\\r\\n]+:(?<currentValue>config-reloader-v\\d+\\.\\d+\\.\\d+)\\\"[\\t ]*-?\\}\\}"
+        "\\{\\{-?[\\t ]*/\\*[\\t ]+#?[\\t ]*renovate: datasource=github-releases depName=VictoriaMetrics/operator versioning=semver-coerced[\\t ]*\\*/[\\t ]*-?\\}\\}[^\\S\\r\\n]*\\r?\\n[\\t ]*\\{\\{-?[\\t ]*print[\\t ]+\\\"[^\\\"\\r\\n]+:config-reloader-v(?<currentValue>\\d+\\.\\d+\\.\\d+)\\\"[\\t ]*-?\\}\\}"
       ],
-      "versioningTemplate": "regex:^config-reloader-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+      "depNameTemplate": "VictoriaMetrics/operator",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver-coerced",
+      "depTypeTemplate": "annotated-version"
     },
     {
       "customType": "regex",
@@ -41,21 +44,13 @@
       "matchStrings": [
         "# renovate-vm-operator[^\\S\\r\\n]*\\r?\\n[\\t ]*image:[\\t ]+victoriametrics/operator:v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
-      "depNameTemplate": "victoriametrics/operator",
-      "datasourceTemplate": "docker",
+      "depNameTemplate": "VictoriaMetrics/operator",
+      "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver-coerced",
       "depTypeTemplate": "annotated-version"
     }
   ],
   "packageRules": [
-    {
-      "description": "Disable digest pinning for prefixed VictoriaMetrics tags",
-      "matchManagers": ["custom.regex"],
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["victoriametrics/operator"],
-      "matchCurrentVersion": "/^config-reloader-v/",
-      "pinDigests": false
-    },
     {
       "description": "Group controller-gen Makefile tool with Kubernetes Go modules",
       "matchManagers": ["custom.regex"],
@@ -89,10 +84,10 @@
       "description": "Keep Prometheus Operator APIs, runtime images, and CRD source version together",
       "matchPackageNames": [
         "github.com/prometheus-operator/prometheus-operator{/,}**",
-        "quay.io/prometheus-operator/prometheus-operator",
-        "quay.io/prometheus-operator/prometheus-config-reloader"
+        "prometheus-operator/prometheus-operator"
       ],
       "groupName": "Prometheus Operator",
+      "minimumGroupSize": 4,
       "prBodyNotes": [
         "This repository bundles Prometheus Operator APIs and assets. Run `make generate-all`, review the generated CRDs and API changes, synchronize custom deployment/RBAC assets when upstream changed them, and commit the reviewed results."
       ]
@@ -101,9 +96,10 @@
       "description": "Keep VictoriaMetrics Operator APIs, runtime images, and CRD source version together",
       "matchPackageNames": [
         "github.com/VictoriaMetrics/operator{/,}**",
-        "victoriametrics/operator"
+        "VictoriaMetrics/operator"
       ],
       "groupName": "VictoriaMetrics Operator",
+      "minimumGroupSize": 9,
       "prBodyNotes": [
         "This repository bundles VictoriaMetrics Operator APIs and assets. Run `make generate-all`, review the generated CRDs and API changes, synchronize custom deployment/RBAC assets when upstream changed them, and commit the reviewed results."
       ]


### PR DESCRIPTION
## Why

Renovate PR [#470](https://github.com/Netcracker/qubership-monitoring-operator/pull/470) updates the Prometheus Operator Go API without the matching runtime images and CRD source version. Quay does not provide release timestamps, so the organization release-age policy filters the image updates before Renovate forms the group. VictoriaMetrics has the same synchronization risk across nine version references.

## What changed

- Use the upstream GitHub releases as version and timestamp sources for annotated Prometheus and VictoriaMetrics image references.
- Require all four Prometheus or all nine VictoriaMetrics references before Renovate creates an operator update branch.
- Add an extraction contract test that verifies reference counts, files, package names, and aligned current versions.
- Keep the existing reviewer notes for generated CRD, API, deployment, and RBAC updates.

## How to verify

- `renovate-config-validator --strict --no-global renovate.json`
- `actionlint .github/workflows/renovate-config-lint.yaml`
- Run Renovate extraction for the managed files and execute `.github/scripts/test-renovate-operator-groups.mjs` against its JSON log.

## Follow-up

After this PR merges, rebase or recreate #470. Run `make generate-all`, commit the generated CRDs, and review the corresponding upstream API, deployment, and RBAC changes before merging the dependency update.