### PR TITLE
fix(grafana): skip canonical no-op updates

### DIFF
--- a/controllers/grafana/grafana_test.go
+++ b/controllers/grafana/grafana_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils/labelsassert"
 	grafv1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -126,6 +127,23 @@ func TestGrafanaManifests(t *testing.T) {
 		}
 		assert.NotNil(t, m, "PodMonitor manifest should not be empty")
 		labelsassert.AssertCRLabels(t, m.GetLabels(), utils.GrafanaComponentName, "victoriametrics-operator", map[string]string{labelKey: labelValue})
+	})
+}
+
+func TestGrafanaPodTemplateAnnotations(t *testing.T) {
+	t.Run("keeps annotations nil when none are configured", func(t *testing.T) {
+		manifest, err := grafana(grafanaComparisonPlatformMonitoring(nil))
+		require.NoError(t, err)
+
+		assert.Nil(t, manifest.Spec.Deployment.Spec.Template.Annotations)
+	})
+
+	t.Run("preserves configured annotations", func(t *testing.T) {
+		annotations := map[string]string{"example.com/key": "value"}
+		manifest, err := grafana(grafanaComparisonPlatformMonitoring(annotations))
+		require.NoError(t, err)
+
+		assert.Equal(t, annotations, manifest.Spec.Deployment.Spec.Template.Annotations)
 	})
 }
 

--- a/controllers/grafana/handlers.go
+++ b/controllers/grafana/handlers.go
@@ -48,19 +48,7 @@ func (r *GrafanaReconciler) handleGrafana(cr *monv1.PlatformMonitoring) error {
 		return err
 	}
 
-	//Set parameters
-	// Only update if something actually changed to avoid unnecessary updates
-	needsUpdate := false
-	if !reflect.DeepEqual(e.Spec, m.Spec) {
-		e.Spec = m.Spec
-		needsUpdate = true
-	}
-	if !reflect.DeepEqual(e.GetLabels(), m.GetLabels()) {
-		e.SetLabels(m.GetLabels())
-		needsUpdate = true
-	}
-
-	if needsUpdate {
+	if applyGrafanaDesiredState(e, m) {
 		if err = r.UpdateResource(e); err != nil {
 			return err
 		}
@@ -72,6 +60,19 @@ func (r *GrafanaReconciler) handleGrafana(cr *monv1.PlatformMonitoring) error {
 	r.Log.Info("Waiting grafana-deployment")
 	time.Sleep(30 * time.Second)
 	return nil
+}
+
+func applyGrafanaDesiredState(existing, desired *grafv1.Grafana) bool {
+	needsUpdate := false
+	if !reflect.DeepEqual(existing.Spec, desired.Spec) {
+		existing.Spec = desired.Spec
+		needsUpdate = true
+	}
+	if !reflect.DeepEqual(existing.GetLabels(), desired.GetLabels()) {
+		existing.SetLabels(desired.GetLabels())
+		needsUpdate = true
+	}
+	return needsUpdate
 }
 
 func (r *GrafanaReconciler) handleGrafanaDataSource(cr *monv1.PlatformMonitoring) error {

--- a/controllers/grafana/handlers_test.go
+++ b/controllers/grafana/handlers_test.go
@@ -40,6 +40,16 @@ func TestApplyGrafanaDesiredStateRemovesStaleAnnotation(t *testing.T) {
 	assert.Nil(t, live.Spec.Deployment.Spec.Template.Annotations)
 }
 
+func TestApplyGrafanaDesiredStateUpdatesChangedLabels(t *testing.T) {
+	desired, err := grafana(grafanaComparisonPlatformMonitoring(nil))
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.Labels = map[string]string{"example.com/stale": "value"}
+
+	assert.True(t, applyGrafanaDesiredState(live, desired))
+	assert.Equal(t, desired.Labels, live.Labels)
+}
+
 func grafanaComparisonPlatformMonitoring(annotations map[string]string) *monv1.PlatformMonitoring {
 	return &monv1.PlatformMonitoring{
 		ObjectMeta: metav1.ObjectMeta{Name: "platformmonitoring", Namespace: "monitoring"},

--- a/controllers/grafana/handlers_test.go
+++ b/controllers/grafana/handlers_test.go
@@ -1,0 +1,50 @@
+package grafana
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApplyGrafanaDesiredStateSkipsAPICanonicalEmptyAnnotations(t *testing.T) {
+	cr := grafanaComparisonPlatformMonitoring(nil)
+	desired, err := grafana(cr)
+	require.NoError(t, err)
+
+	live := desired.DeepCopy()
+	live.Spec.Deployment.Spec.Template.Annotations = nil
+
+	assert.False(t, applyGrafanaDesiredState(live, desired))
+}
+
+func TestApplyGrafanaDesiredStateUpdatesChangedAnnotation(t *testing.T) {
+	desired, err := grafana(grafanaComparisonPlatformMonitoring(map[string]string{"example.com/key": "desired"}))
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.Spec.Deployment.Spec.Template.Annotations["example.com/key"] = "stale"
+
+	assert.True(t, applyGrafanaDesiredState(live, desired))
+	assert.Equal(t, map[string]string{"example.com/key": "desired"}, live.Spec.Deployment.Spec.Template.Annotations)
+}
+
+func TestApplyGrafanaDesiredStateRemovesStaleAnnotation(t *testing.T) {
+	desired, err := grafana(grafanaComparisonPlatformMonitoring(nil))
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.Spec.Deployment.Spec.Template.Annotations = map[string]string{"example.com/stale": "value"}
+
+	assert.True(t, applyGrafanaDesiredState(live, desired))
+	assert.Nil(t, live.Spec.Deployment.Spec.Template.Annotations)
+}
+
+func grafanaComparisonPlatformMonitoring(annotations map[string]string) *monv1.PlatformMonitoring {
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{Name: "platformmonitoring", Namespace: "monitoring"},
+		Spec: monv1.PlatformMonitoringSpec{
+			Grafana: &monv1.Grafana{Annotations: annotations},
+		},
+	}
+}

--- a/controllers/grafana/manifest.go
+++ b/controllers/grafana/manifest.go
@@ -502,10 +502,10 @@ func grafana(cr *monv1.PlatformMonitoring) (*grafv1.Grafana, error) {
 			}
 		}
 
-		if deployment.Spec.Template.Annotations == nil {
-			deployment.Spec.Template.Annotations = make(map[string]string)
-		}
-		if cr.Spec.Grafana.Annotations != nil {
+		if len(cr.Spec.Grafana.Annotations) > 0 {
+			if deployment.Spec.Template.Annotations == nil {
+				deployment.Spec.Template.Annotations = make(map[string]string, len(cr.Spec.Grafana.Annotations))
+			}
 			for k, v := range cr.Spec.Grafana.Annotations {
 				deployment.Spec.Template.Annotations[k] = v
 			}


### PR DESCRIPTION
## Why

The monitoring operator attempted to update the managed Grafana CR on every periodic reconciliation. The desired manifest used an empty pod-template annotation map, while the API server returned the omitted field as `nil`, so `reflect.DeepEqual` always reported drift.

Part of #473. This PR covers only the residual Grafana CR update described in that issue.

## What

- Leave `spec.deployment.spec.template.metadata.annotations` unset when no Grafana pod-template annotations are configured.
- Preserve reconciliation of pod-template annotation additions, changes, and removals.
- Extract the existing spec and label update decision into a testable helper without changing handler behavior.
- Add regression tests for API-server canonicalization, pod-template annotation drift repair, and label drift repair.

The change does not modify Grafana CR metadata reconciliation, CRDs, Helm values, RBAC, images, or platform-specific resources.

## How to verify

- `go test -race ./controllers/grafana -count=1`
- `make test`
- Kind: two complete periodic reconciliation windows contained no `Successful updating res=Grafana` log entry; Grafana remained Ready.