### PR TITLE
docs(agents): record the traps this repository sets for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,12 @@ Build / test (from repository root):
 
 Running a single Go test: `go test -v -run <TestName> ./controllers/<pkg>/...`.
 
-Envtests (`test/envtests/`) require `kube-apiserver` and `etcd` binaries and are excluded from `make test`. CI runs them
-against the minimum supported Kubernetes 1.25, and the build workflow also covers Kubernetes 1.30. Run `make envtest`;
-the target installs the pinned `setup-envtest` tool and downloads the requested Kubernetes assets.
+Envtests (`test/envtests/`) require `kube-apiserver` and `etcd` binaries and are excluded from `make test`. Run
+`make envtest`; the target installs the pinned `setup-envtest` tool and downloads the requested Kubernetes assets.
+
+Only the dedicated minimum-version job runs them in CI. The coverage job provisions envtest assets but invokes a
+plain package-wildcard test run, and every file in that directory carries a build tag — so it compiles none of the
+suite and still reports success. See `test/AGENTS.md`.
 
 For a source install, follow the CRD ownership contract in the [quick-start guide](README.md#quick-start):
 
@@ -120,6 +123,87 @@ same sources for release.
 
 ### Version ldflags
 
-Build version info is injected at link time via
-`-X github.com/Netcracker/qubership-monitoring-operator/version.{Revision,BuildUser,BuildDate,Branch,Version}` (see
-`Makefile` `GO_BUILD_LDFLAGS`). The `Dockerfile` does **not** pass these flags; only `make build-binary` does.
+`Makefile` `GO_BUILD_LDFLAGS` passes `-X <module>/version.{Revision,BuildUser,BuildDate,Branch,Version}`, and the
+`Dockerfile` does not pass them at all. Note that **the injection is a no-op**: no `version` package exists in the
+tree, and the linker accepts `-X` for an absent symbol without a warning, so the build succeeds and the binary
+carries nothing. Verify version stamping by inspecting a built binary, never by reading these flags.
+
+## Traps this repository sets
+
+Distilled from reviews in which several dozen agents worked this repository independently. Everything here is
+something more than one of them got wrong or lost significant time to. These are observations, not policy — if one
+stops being true, correct it.
+
+Scoped notes live next to the code they describe: `api/v1/`, `controllers/`, `charts/`, `test/`.
+
+### A green test run is compatible with completely broken reconciliation
+
+No test calls the top-level `Reconcile`, and the default unit target excludes the envtest suite. Agents inverted the
+Prometheus-versus-VictoriaMetrics defaulting rule and removed `Paused` guards from several sub-reconcilers; the full
+suite still passed. The race detector finds nothing because the non-test code has no goroutines, channels, or
+mutexes at all.
+
+Prove any reconciler claim with a probe you write. See `test/AGENTS.md` before running the envtest suite — it is
+gated behind a build tag, so the obvious command runs none of it and still exits 0.
+
+### The CR status is a transcript of the current pass, not a state
+
+A healthy stack reports the aggregate condition as `In progress` / `False` for roughly a third to a half of every
+cycle, because the controller writes that at the start of each pass and the terminal state at the end. A single
+`kubectl get platformmonitoring -o jsonpath='{.status.conditions}'` is therefore a coin flip.
+
+Sample across at least two full intervals and report the fraction. The transition timestamp is Go's `time.Time`
+string form including the monotonic-clock reading, and the schema declares it a plain string — no date parser will
+accept it, so never feed it to `jq` or `date`.
+
+### Working on the live cluster
+
+Treat every CR patch as destructive: setting a component's install flag to false does not idle the component, it
+takes the uninstall branch and deletes the running workload within a reconcile cycle. Restore immediately.
+
+Assume other writers. Reviews here run several agents against one cluster, so a deployment's environment, a bound
+port, or a stray manager process may be someone else's. Re-read the deployment env before trusting any rate or
+counter measurement, and capture the object before and after your own change rather than inferring causation.
+
+Do not run the operator binary to inspect its flags. There is no early exit for informational flags — the process
+falls through to loading the current kubeconfig and starts reconciling, so probing `--help` or `--version` starts a
+second operator against whatever cluster you are pointed at. Most of its ~100 flags come from an imported metrics
+library and control nothing here.
+
+An incomplete RBAC grant makes the operator hang rather than fail: the cache waits on a watch that never syncs,
+reconciler logs stay silent and the CR status says nothing. Look for the cache component's own log lines.
+
+### Reading command output
+
+Never take an exit status from the end of a pipeline, and never discard stderr from a chart render. This chart
+genuinely fails to render under ordinary value combinations, so `helm template … 2>/dev/null | grep -c` cannot
+distinguish "the resource is absent" from "nothing rendered at all". Several agents drew conclusions from a
+truncated or piped result — including one who read `list … | head -20` of a descending list as the complete set.
+
+Commands here that reach the network — the CRD refresh targets, the envtest asset download, image pulls — are slow
+and flaky in proportion to the link, not to the repository. A single timing is not evidence of a build defect, and
+a hang on first use is usually the registry. Retry before reporting.
+
+### Tooling lives in a gitignored directory under version-suffixed names
+
+The Makefile downloads pinned binaries into the local `bin/` directory as `<tool>-<version>`, so a tool absent from
+`PATH` is not absent from the project — list or glob that directory before concluding a check cannot be run. In a
+fresh clone or worktree the directory is empty and the repository's own verification scripts abort; run the make
+target that provisions them rather than copying binaries between trees.
+
+Several verification scripts under `tools/` use bash-4 builtins under `set -e`. On a default macOS shell they either
+abort partway or, worse, iterate an empty input list and exit 0 — a partial run and a clean pass look identical. Run
+them with a modern bash and confirm they printed results.
+
+Much of the project's real verification lives in those scripts and is invoked only from workflows, never from the
+Makefile. Grep the workflows as well before asserting that something is unverified.
+
+### What CI does not check
+
+The linter env file disables Go linting and Kubernetes schema validation, no workflow invokes the Go linter, and the
+linter rules are fetched at run time from an organization repository on a moving branch. Merges are gated on no
+required status check at all. The workflow that produces coverage does not use the documented test target and runs
+without the race detector or shuffling.
+
+Presence of a lint config in the tree is not evidence the linter has ever run; a green pipeline is not evidence the
+documented flags ran.

--- a/api/v1/AGENTS.md
+++ b/api/v1/AGENTS.md
@@ -1,0 +1,58 @@
+# The API types
+
+Read the root `AGENTS.md` first. This file covers the traps specific to the CR surface.
+
+## The stored spec is not the effective spec
+
+`FillEmptyWithDefaults()` rewrites the spec in memory on every pass, and only the status subresource is persisted.
+It force-disables a component when a conflicting backend is enabled, so an explicitly requested component can be
+off while the stored CR still shows it on, and the only signal is a deprecation condition whose message does not
+say the request was overridden.
+
+Read that function before concluding anything about which components are active from a chart render or from a live
+CR.
+
+## A field in the Go type is not necessarily in the API
+
+At least one component field carries a struct tag that excludes it from serialization, with the real tag commented
+out beside it, so the generated CRD has no such property while the chart still renders one. The field is pruned by
+a client-side apply and rejected outright by a server-side strict apply, and the decoded spec always holds the zero
+value.
+
+A Go-constructed CR in a test bypasses the API server's structural-schema pruning exactly as a chart render does,
+so either can "prove" a code path that no real cluster can reach. Check the generated CRD for the property and the
+Go field's tag before believing a spec field matters.
+
+## The install predicates are not uniform
+
+Some `IsInstall()` helpers return the install flag alone; the VictoriaMetrics ones also require the component's
+image fields to be non-empty, and the cluster variant requires all three of its images. Nothing in the doc comments
+says so, and a component that fails the predicate is uninstalled rather than skipped. Read the specific
+component's predicate rather than generalizing from a sibling — see `controllers/AGENTS.md`.
+
+Relatedly, the schema marks a dozen-plus component fields required even though the defaulting pass would have
+filled them, so a hand-written minimal CR is rejected by the API server. For dry-run probes, satisfy them with
+empty strings — there is no minimum-length constraint.
+
+## Generated artifacts
+
+The CRD is generator output with all field descriptions stripped to stay under the object-size limit, then patched
+further by path-addressed YAML expressions. Consequences:
+
+- `kubectl explain` returns nothing for every field, and the CRD YAML carries structure only. These Go types are
+  the documentation.
+- The patches address absolute paths, no-op silently when a path moves, and can create phantom nodes when applied
+  to a missing path. Nothing verifies that a patch landed.
+- The same CRD ships in more than one chart, and the copies have drifted historically. State which copy you used.
+
+Do not hand-edit the CRD. Regenerate, and expect the committed file to differ from raw generator output by the
+post-processing.
+
+## The status contract
+
+The transition timestamp is written with Go's `time.Time` string form, including the monotonic-clock reading, and
+the schema declares the field a plain string with no date format, so the API server accepts it and no date parser
+will. The no-op detection compares that field against itself, so it can never report "unchanged".
+
+The aggregate condition is a transcript of the current pass rather than a settled state. See the root file before
+reading it.

--- a/api/v1/CLAUDE.md
+++ b/api/v1/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/charts/AGENTS.md
+++ b/charts/AGENTS.md
@@ -1,0 +1,120 @@
+# The charts
+
+Read the root `AGENTS.md` first. This file covers the traps specific to the chart tree.
+
+## The parent chart is a fraction of the chart
+
+The largest components are vendored subchart directories, each with its own values file, templates, and lifecycle
+hooks, merged under the parent key of the same name. The parent values file does not even mention the biggest
+components. Agents concluded three separate times that a knob was invented, that a dependency condition was dead,
+and that a pre-delete hook did not exist — all from grepping the parent alone.
+
+Search the whole chart tree. A dependency `condition:` resolves against coalesced parent-plus-subchart values, so
+absence from the parent values file never means "not a knob".
+
+Two mechanics worth knowing before you reason about a toggle:
+
+- A `condition:` holding several comma-separated paths is **not** an OR. Helm stops at the first path that exists in
+  the coalesced values, so a second path is unreachable while the first ships with a default.
+- A subchart is enabled by an exact key-path match against its `condition:`. A differently-cased or differently
+  punctuated block in the parent values is a dead knob that renders without error.
+
+## A render is a conditional projection, not an inventory
+
+Never conclude "this resource does not exist" from a render. Four independent mechanisms shrink the output:
+
+- **Cluster capabilities.** Many templates and several subchart helpers branch on `Capabilities.APIVersions.Has`,
+  so every OpenShift security-constraint object and every pod-security-policy object disappears unless you pass the
+  capability explicitly. Audits of platform-specific behavior must set it.
+- **`lookup`.** Credential templates branch on a cluster read that returns nil offline, so a client-side render
+  always takes the "does not exist yet" branch. An object present in the render may never be created by a real
+  install, and vice versa. Confirm ownership on a cluster through the release annotations and field managers.
+- **Sibling guards.** At least one CR block is nested inside an unrelated component's guard, so setting it alone
+  renders nothing.
+- **Defaults already on.** A zero diff after enabling a toggle usually means the default was already true.
+
+Local rendering also evaluates no cluster state, so it cannot reveal a conflict over a cluster-scoped name already
+owned by another release. Use a server-side dry run for that.
+
+## Values are not validated, in either direction
+
+No values schema sets `additionalProperties: false`, and several top-level keys are absent from the schema
+entirely. Misspelled keys render clean, lint clean, and do nothing — including a misspelling in the *disable*
+direction, which leaves the component on. Verify an override by diffing the render against the unset baseline,
+never by an exit code.
+
+Two shipped artifacts demonstrate the failure mode: the resource profiles are single-line files written in dotted
+key form, which Helm expands only for `--set` and never for `-f`, so all of them render byte-identical to the
+default; and at least one example overlay sets a key spelled differently from the condition that reads it.
+
+The same concept is also spelled differently across sibling subcharts — the nested toggle that gates a monitor
+object is `.enabled` in about half of them and `.install` in the rest. Grep the specific subchart's template for
+the condition before setting anything nested.
+
+Numeric values pass through Helm's `default`, which treats zero as unset, so an explicit scale-to-zero silently
+becomes one replica.
+
+## What the chart renders is not what the operator receives
+
+The chart renders CR fields the CRD does not declare, because a Go struct tag excludes them from serialization
+while the template still emits them. What happens then depends on the apply path: a server-side strict apply
+rejects the whole object and fails the release, while a client-side apply prunes the field in silence. Either way
+the operator sees the zero value.
+
+Beyond that, a defaulting pass rewrites component enable flags in memory before reconciliation and only the status
+subresource is persisted — so the stored CR shows what the user asked for, not what the operator does.
+
+Before believing a values key works, check the CRD for the property and the Go field's tag. `helm template` showing
+a field proves nothing.
+
+## Installing, upgrading, and removing
+
+`--wait` covers only the chart's own objects. Nearly everything that matters is created afterwards by the
+operator, so a successful upgrade or rollback exit code says nothing about convergence — gate on the custom
+resource's status conditions and the managed workloads instead.
+
+Lifecycle hooks are the main source of grief:
+
+- The post-install and post-upgrade hook assumes a control-plane topology a development cluster does not have. It
+  can stall for the whole timeout and leave the release `failed` while every workload is fine. Expect to pass
+  `--no-hooks` on upgrades as well as installs.
+- Pre-delete hooks act on the whole namespace rather than on release-owned objects, so an uninstall destroys
+  matching custom resources somebody else created by hand. Never uninstall in a namespace holding anything you
+  care about, and read the hook pod logs — Helm's own "kept due to resource policy" summary does not reflect what
+  the hooks did.
+- Hook resources are retained across uninstall and must be deleted by hand before reinstalling; a failed hook can
+  leave the release neither installed nor removable except with `--no-hooks`.
+
+Rollback additionally trips over immutable fields changed between versions, and reports success while the stack
+never converges.
+
+Several cluster-scoped names are hardcoded without a release or namespace prefix, so a second release in the same
+cluster collides — and the managed operators watch all namespaces by default, so the first release's operators
+reconcile and finalize the second one's resources. Side-by-side experiments are contaminated unless you isolate
+them deliberately.
+
+## CRDs
+
+The same CRD is shipped in more than one chart and the copies have drifted by weeks in the past, so any schema
+comparison must state which copy it used. Files are named for the fully-qualified CRD, not the component, and a
+subchart's CRD directory is not restricted to that subchart.
+
+The shipped CRDs are generator output post-processed by path-addressed YAML patches. Every field description is
+stripped to stay under the object-size limit, so cluster-side introspection teaches nothing about field meaning —
+read the Go types. The patches address absolute paths and no-op silently when an upstream path moves, and a
+deletion against a missing path exits zero, so the guard passes vacuously.
+
+## Chart tooling
+
+The chart-lint step packages every vendored subchart into the source tree and neither the archives nor the lock
+file are ignored, so it leaves the working tree dirty beside directories that are already tracked. Clean up before
+reading a diff.
+
+That step also copies the example profiles with a recursive glob that does not recurse in CI's shell and then
+selects them by filename suffix, so well under half of the documented profiles ever reach the linter. It runs
+without an install phase and with the chart-version gate switched off. A green chart job is not evidence that a
+profile, a rendered manifest, or a version bump was checked.
+
+The locally installed Helm is likely a major version ahead of the one CI installs, and the majors differ on flags,
+on `lookup`, on hook handling, and on whether an unknown field is pruned or fails the release. Check the version
+before reasoning from documentation or from a local result.

--- a/charts/CLAUDE.md
+++ b/charts/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/controllers/AGENTS.md
+++ b/controllers/AGENTS.md
@@ -1,0 +1,70 @@
+# The controllers
+
+Read the root `AGENTS.md` first. This file covers the traps specific to the reconcilers.
+
+## Enablement is not the boolean it looks like
+
+The `IsInstall()` helpers are not uniform. Some check only the install flag; the VictoriaMetrics ones are
+conjunctions that also require the component's image fields to be non-empty, and the cluster variant requires all
+three of its images. The doc comments do not say so, and several agents built probes that set only the flag and
+silently exercised the disabled path. Read the specific component's predicate rather than generalizing from a
+sibling.
+
+Worse, the reconcilers branch on the same predicate and a component that fails it is **actively uninstalled**, not
+skipped — a hand-built CR without images deletes live resources. Populate images in every fixture, and never read
+`install: true` as "this component is on".
+
+The same applies on a cluster: flipping a component's install flag to false in a live CR deletes its workload
+within a cycle.
+
+## The embedded assets are templates, not manifests
+
+Files under each component's `assets/` directory are loaded and then mutated by the Go handlers before they are
+applied, so reading an asset tells you little:
+
+- Several cluster-role assets ship with an empty rule list; the rules are appended at reconcile time. "No
+  permissions" is the wrong conclusion.
+- At least one asset is a zero-length file that is still pulled in by the embed directive, and at least one
+  constant points at an asset that does not exist. A `Must…` accessor here does not panic — it discards the error
+  and returns empty, so a missing asset surfaces far away as an opaque decode error.
+- Values visible in an asset can be overwritten unconditionally from the CR, including with nil. A default install
+  can therefore end up without a field the asset clearly sets.
+
+Read the matching `manifest.go` / `handlers.go`, or exercise the builder from a test, before asserting what the
+operator applies. And confirm against the deployed object rather than the asset.
+
+## Writing probes
+
+Nothing exercises reconciliation, so any behavioral claim needs a probe you write. Two harnesses, both with edges:
+
+- **The controller-runtime fake client alone panics.** The reconcilers hold a discovery client and probe for
+  optional APIs before creating anything; the fake provides none. Inject a fake clientset with the relevant API
+  groups populated.
+- **The fake client also invents failures.** It deep-copies where the real client path does not, which raises
+  panics on unstructured objects that a real cluster never triggers. Confirm both directions against the
+  API-server-backed suite before believing a fake-client result.
+
+Trace callers to a top-level entry point before treating a function as live. Several helpers here are retained for
+manual recovery and are reachable only from other unused code — while the RBAC grants and status semantics they
+motivated are still shipped.
+
+## Reconcile timing and cancellation
+
+A single pass blocks for tens of seconds by design — one component handler sleeps unconditionally — and the requeue
+is measured from the end of the pass, so the effective period is substantially longer than the configured interval.
+The context is not propagated into the sub-reconcilers, so a pass ignores cancellation and pod termination consumes
+most of the grace period.
+
+Budget for this when polling for an effect, and do not read a slow status update as a hang. Note also that the
+reconcile method names its context parameter after the `context` package, so grep-based reasoning about which calls
+receive a cancellable context is unreliable in that file.
+
+## RBAC is hand-written, not generated
+
+Unlike a stock kubebuilder project, the operator's `Role` and `ClusterRole` are hand-maintained chart templates.
+The tree holds only a handful of RBAC markers and there is no generated RBAC directory, so adding an API call to a
+reconciler does not update permissions and no generator or drift check will catch the omission. It surfaces on a
+cluster as a watch that never syncs — the operator hangs rather than failing, and the reconciler logs say nothing.
+
+Whenever you add a call, update the chart templates by hand, and check the delegation script under `tools/` that
+verifies the parent role covers what the child roles need.

--- a/controllers/CLAUDE.md
+++ b/controllers/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,69 @@
+# The test suites
+
+Read the root `AGENTS.md` first. This file covers the traps specific to the tests.
+
+## A passing run frequently means nothing ran
+
+Every file in the envtest directory carries a build tag, so a plain package-wildcard run compiles none of it,
+matches no packages, and **exits 0**. Pass the tag explicitly. A CI job that merely provisions control-plane assets
+is not evidence that the suite ran.
+
+The unit suite never calls the top-level reconcile entry point, and the envtest specs call component reconcilers
+directly rather than through it, so status conditions are never asserted by anything. Mutations to defaulting rules
+and to component guards have survived the full suite. Mutate the line you care about and re-run before claiming a
+behavior is covered.
+
+The environment has no scheduler and no kubelet, so a custom resource can reach its success condition with zero
+ready replicas and no pods — "the workloads came up" is never actually tested there.
+
+## The suite is order-dependent
+
+The privileged-rights mode is a mutable package-level global that one spec sets through a flag and never restores,
+while another assumes the zero value. Container order is randomized, so which mode the specs exercise is decided by
+the seed, and neither ordering asserts the negative case. Pin the seed and assert the mode explicitly; a single
+green run does not establish which contract was tested.
+
+## Reading the output
+
+Diagnostics written through the test logger go to the Ginkgo writer and are invisible for passing specs unless
+verbose Ginkgo output is requested on the test binary — `go test -v` alone is not enough. Several agents saw a
+clean `ok` line with zero occurrences of their own probe output.
+
+Focusing specs makes the package exit non-zero even when every executed spec passes, which reads as a failure.
+Read the spec summary line rather than the exit code, and never leave focus in a committed test.
+
+A Go coverage profile lists only packages the test binary links, so a package missing from the report is untested
+rather than at zero — absence is not a measurement.
+
+## Assets and stubs
+
+The third-party CRDs used by the envtest suite are hand-written stubs that declare no properties and preserve
+unknown fields, so the API server accepts any spec. A passing create there proves only that the request was
+well-formed JSON. Assert on the object you read back.
+
+The asset custom resource sets the non-default privilege mode, so the default path is not what the suite
+exercises.
+
+## A baseline failure is probably not yours
+
+One test in the API-types package reconstructs the repository root by walking up and then re-appending the
+project's own directory name, so the whole package fails in a git worktree, in a renamed clone, or on a CI path.
+Establish a baseline run before attributing any failure to your change.
+
+That same test's only assertion cannot fail — it checks a struct value for nil — so when it passes it proves only
+that a file opened and decoded.
+
+## Integration tests
+
+The Robot suites are split between this repository and an upstream base image: keywords and the tag resolver live
+on the image side, so an unresolved keyword or an apparently uncalled helper is usually defined there. Only
+`.robot` files are executed — Python test files sitting beside them are copied into the image and run by nothing,
+including the only automated regression test for at least one past fix.
+
+The tag-exclusion logic treats an unset variable the same as a disabled one, and the exclusion list names
+components the chart never exports, so those suites can never run even when the component is installed.
+
+Keywords wrap calls in long retry loops, which makes a hard failure indistinguishable from a slow start. Read the
+pod's actual environment rather than trusting elapsed time — a malformed value rendered into an environment
+variable is a common cause, and the templates emit Go's formatting placeholder for an undefined value without any
+render error.

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Notes for AI agents working this repository, distilled from reviews in which several dozen agents worked it independently. Only traps that more than one of them hit on their own are included; single-occurrence and machine-specific ones were left out.

## Why

Agents repeatedly lost time to, or drew wrong conclusions from, the same handful of properties of this repository. Several published findings that were artifacts of those properties rather than defects. The cheapest fix is to write the traps down where an agent will read them.

## What

A `## Traps this repository sets` section in the root `AGENTS.md`, plus scoped notes next to the code they describe — `api/v1/`, `controllers/`, `charts/`, `test/` — each with a `CLAUDE.md` pointing at it. Scoping matters here: an agent working in the chart tree should not have to read reconciler traps to find the one about render conditionals.

The recurring themes:

- **A green test run is compatible with completely broken reconciliation.** Nothing calls the reconcile entry point, and every file in the integration suite carries a build tag, so the obvious package-wildcard command compiles none of it and still exits 0. Mutations to defaulting rules and component guards survived the full suite.
- **The CR status is a transcript of the current pass, not a settled state.** A healthy stack reports the aggregate condition as false for a third to a half of every cycle, so a single read is a coin flip; the transition timestamp is a Go time string with a monotonic-clock suffix that no date parser accepts.
- **A chart render is a conditional projection.** Cluster capabilities, `lookup`, sibling guards, and defaults that are already on each shrink the output, so "not in the render" is not "not in the chart" — and the chart renders CR fields the CRD does not declare, which are pruned or rejected depending on the apply path.
- **Values are unvalidated in both directions.** No schema forbids unknown keys, so a misspelled key renders clean and does nothing, including in the disable direction. Two shipped artifacts demonstrate it.
- **Lifecycle hooks make uninstall and rollback destructive rather than reversible**, act on the whole namespace rather than on release-owned objects, and exceed Helm default timeouts.
- **Working on a live cluster**: flipping a component off deletes its workload rather than idling it, and running the operator binary to inspect its flags starts a second operator against the current kubeconfig.

## Corrections

Two statements already in `AGENTS.md` were wrong and are fixed:

- The version ldflags target a `version` package that does not exist in the tree. The linker accepts `-X` for an absent symbol without a warning, so the injection is a silent no-op and the shipped binary carries no version.
- The claim that the build workflow also covers a second Kubernetes version did not hold: that job provisions envtest assets but runs a command that compiles none of the suite.

## How to verify

Everything here was observed in agent trajectories and re-checked against the current tree. The load-bearing claims are cheap to confirm directly, for example:

```bash
ls version                                        # absent — the ldflags are a no-op
grep -l "go:build envtest" test/envtests/*.go     # all of them
grep -c additionalProperties charts/qubership-monitoring-operator/values.schema.json   # 0
cat charts/qubership-monitoring-operator/resource-profiles/large.yaml                  # dotted key, a no-op under -f
```

Documentation only — no code, chart, or CI behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)