### PR TITLE
fix(victoriametrics): preserve VMSingle PVCs

### DIFF
--- a/charts/qubership-monitoring-operator/charts/victoriametrics/templates/pre-delete/job.yaml
+++ b/charts/qubership-monitoring-operator/charts/victoriametrics/templates/pre-delete/job.yaml
@@ -55,6 +55,8 @@ spec:
               set -eu;
               kubectl scale deployment --replicas=0 --selector app.kubernetes.io/component=qubership-monitoring-operator;
               sleep {{ .Values.cleanup.hook.timeout | default "10" }};
-              kubectl delete vmusers,vmauths,vmalerts,vmagents,vmsingles,vmalertmanagers,vmclusters
+              kubectl delete vmsingles --all --ignore-not-found=true --wait=true
+              --cascade=orphan --timeout={{ .Values.cleanup.hook.deleteTimeout }};
+              kubectl delete vmusers,vmauths,vmalerts,vmagents,vmalertmanagers,vmclusters
               --all --ignore-not-found=true --wait=true --timeout={{ .Values.cleanup.hook.deleteTimeout }};
 {{- end -}}

--- a/controllers/victoriametrics/vmsingle/assets/vmsingle.yaml
+++ b/controllers/victoriametrics/vmsingle/assets/vmsingle.yaml
@@ -13,7 +13,7 @@ spec:
     search.maxPointsPerTimeseries: "150000"
   replicaCount: 1
   resources: {}
-  removePvcAfterDelete: true
+  removePvcAfterDelete: false
   retentionPeriod: "14"
   securityContext:
     runAsUser: 2000

--- a/controllers/victoriametrics/vmsingle/handlers.go
+++ b/controllers/victoriametrics/vmsingle/handlers.go
@@ -1,6 +1,8 @@
 package vmsingle
 
 import (
+	"context"
+
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	vmetricsv1b1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
@@ -9,6 +11,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *VmSingleReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring) error {
@@ -237,9 +240,14 @@ func (r *VmSingleReconciler) deleteVmSingle(cr *monv1.PlatformMonitoring) error 
 		}
 		return err
 	}
-	if err = r.DeleteResource(e); err != nil {
+	if err = r.Client.Delete(
+		context.TODO(),
+		e,
+		client.PropagationPolicy(metav1.DeletePropagationOrphan),
+	); err != nil {
 		return err
 	}
+	r.Log.Info("Successful deleting", utils.ResourceKey, e.GetObjectKind().GroupVersionKind().Kind)
 	return nil
 }
 

--- a/controllers/victoriametrics/vmsingle/vmsingle_test.go
+++ b/controllers/victoriametrics/vmsingle/vmsingle_test.go
@@ -1,13 +1,33 @@
 package vmsingle
 
 import (
+	"context"
 	"testing"
 
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	vmetricsv1b1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+type deleteOptionsRecordingClient struct {
+	client.Client
+	deleteOptions client.DeleteOptions
+}
+
+func (c *deleteOptionsRecordingClient) Delete(
+	ctx context.Context,
+	obj client.Object,
+	opts ...client.DeleteOption,
+) error {
+	c.deleteOptions.ApplyOptions(opts)
+	return c.Client.Delete(ctx, obj, opts...)
+}
 
 var (
 	cr *monv1.PlatformMonitoring
@@ -93,6 +113,92 @@ func TestVmSingleUsesOperatorVmAlertURL(t *testing.T) {
 		"http://vmalert-k8s.monitoring.svc:8080",
 		manifest.Spec.ExtraArgs["vmalert.proxyURL"],
 	)
+}
+
+func TestVmSinglePreservesPVCByDefault(t *testing.T) {
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "monitoring",
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Victoriametrics: &monv1.Victoriametrics{
+				VmSingle: monv1.VmSingle{
+					Image: "vmsingle:current",
+				},
+			},
+		},
+	}
+
+	manifest, err := vmSingle(nil, cr)
+	require.NoError(t, err)
+
+	assert.False(t, manifest.Spec.RemovePvcAfterDelete)
+}
+
+func TestHandleVmSingleDisablesPVCRemovalOnUpgrade(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, vmetricsv1b1.AddToScheme(scheme))
+
+	existing := &vmetricsv1b1.VMSingle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "k8s",
+			Namespace: "monitoring",
+		},
+		Spec: vmetricsv1b1.VMSingleSpec{
+			RemovePvcAfterDelete: true,
+		},
+	}
+	controllerClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	reconciler := NewVmSingleReconciler(controllerClient, scheme, nil)
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Victoriametrics: &monv1.Victoriametrics{
+				VmSingle: monv1.VmSingle{
+					Image: "vmsingle:current",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, reconciler.handleVmSingle(cr))
+
+	updated := &vmetricsv1b1.VMSingle{}
+	require.NoError(t, controllerClient.Get(
+		context.Background(),
+		types.NamespacedName{Name: "k8s", Namespace: "monitoring"},
+		updated,
+	))
+	assert.False(t, updated.Spec.RemovePvcAfterDelete)
+}
+
+func TestDeleteVmSingleUsesOrphanPropagation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, vmetricsv1b1.AddToScheme(scheme))
+
+	existing := &vmetricsv1b1.VMSingle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "k8s",
+			Namespace: "monitoring",
+		},
+	}
+	controllerClient := &deleteOptionsRecordingClient{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build(),
+	}
+	reconciler := NewVmSingleReconciler(controllerClient, scheme, nil)
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+		},
+	}
+
+	require.NoError(t, reconciler.deleteVmSingle(cr))
+	require.NotNil(t, controllerClient.deleteOptions.PropagationPolicy)
+	assert.Equal(t, metav1.DeletePropagationOrphan, *controllerClient.deleteOptions.PropagationPolicy)
 }
 
 func TestVmSingleClusterRBACUsesInstallationNamespace(t *testing.T) {

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -191,6 +191,7 @@ After executing the command, all Monitoring components are removed from the sele
 objects are not removed:
 
 * `monitoring-operator`
+* Persistent VMSingle PVCs
 * Some cluster entities like ClusterRoles, ClusterRoleBindings, Security Context Constraints (SCC), and Pod Security
   Policy (PSP)
 
@@ -209,6 +210,11 @@ helm list -n <namespace>
 ```
 
 The command removes all the Kubernetes/OpenShift components associated with the chart and deletes the release.
+
+Persistent VMSingle PVCs remain after uninstall. Reinstalling the same monitoring
+instance can reuse them. To remove the stored metrics, identify and delete the exact
+PVC manually; persistent-volume retention then follows the storage class reclaim
+policy.
 
 #### Remove all Created CRDs
 

--- a/tools/verify-helm-crds.sh
+++ b/tools/verify-helm-crds.sh
@@ -588,6 +588,12 @@ verify_exact_rbac_verbs "${rbac_cleanup_role_manifest}" rbac.authorization.k8s.i
     "${rendered_manifest}" >"${cleanup_command}"
 verify_text_excludes "${cleanup_command}" "clusterrolebindings" "cluster RBAC deletion before operators stop"
 verify_text_excludes "${cleanup_command}" "clusterroles" "cluster RBAC deletion before operators stop"
+verify_text_contains "${cleanup_command}" \
+    "kubectl delete vmsingles --all" "separate VMSingle cleanup"
+verify_text_contains "${cleanup_command}" \
+    "--cascade=orphan" "VMSingle PVC-preserving cleanup"
+verify_text_excludes "${cleanup_command}" \
+    "vmagents,vmsingles" "VMSingle deletion in the cascading VM resource cleanup"
 "${yq_binary}" eval-all \
     'select(.kind == "Job" and .metadata.name == "monitoring-rbac-cleanup-hook") |
     .spec.template.spec.containers[] | select(.name == "kubectl") | .command[-1]' \


### PR DESCRIPTION
# What does this PR do?

Preserves VMSingle metrics storage when the component, PlatformMonitoring resource, or Helm release is removed.

The operator stops setting `removePvcAfterDelete: true`. VMSingle deletion uses orphan propagation so the VictoriaMetrics Operator can clean up its managed resources without the garbage collector racing the PVC. The Helm cleanup hook deletes VMSingle separately for the same reason. Documentation covers retained claims and explicit data deletion.

## Why

Existing installations can lose the VMSingle PVC during component disablement or uninstall. Persistent metrics storage should survive deployment lifecycle operations unless the user explicitly removes it.

Closes #484.

## Verification

- Existing `removePvcAfterDelete: true` reconciles to `false`.
- Kind retained the same PVC and PV UIDs across component disable/enable, PlatformMonitoring deletion/recreation, and Helm uninstall/reinstall.
- Historical VictoriaMetrics queries returned samples written before reinstall.
- `make test`, Helm lint, chart verification, and `git diff --check` pass.

## Checklist

- [x] `make generate` not required; `api/v1/*.go` did not change
- [x] `make test` passes
- [x] Docs updated
