### PR TITLE
fix: pin operator and integration-tests images to 0.88.1

### DIFF
--- a/charts/qubership-monitoring-operator/templates/_images.tpl
+++ b/charts/qubership-monitoring-operator/templates/_images.tpl
@@ -12,7 +12,7 @@ Image can be found from:
   {{- if .Values.monitoringOperator.image -}}
     {{- printf "%s" .Values.monitoringOperator.image -}}
   {{- else -}}
-    {{- print "ghcr.io/netcracker/qubership-monitoring-operator:0.88.0" -}}
+    {{- print "ghcr.io/netcracker/qubership-monitoring-operator:0.88.1" -}}
   {{- end -}}
 {{- end -}}
 
@@ -400,7 +400,7 @@ Image can be found from:
   {{- if .Values.integrationTests.image -}}
     {{- printf "%s" .Values.integrationTests.image -}}
   {{- else -}}
-    {{- print "ghcr.io/netcracker/qubership-monitoring-int-tests:main" -}}
+    {{- print "ghcr.io/netcracker/qubership-monitoring-int-tests:0.88.1" -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
# What does this PR do?
Pins monitoring-int-tests to the defined version instead of main.

## Why

The drift between operator and integration tests versions causes fail of update cases of monitoring test pipeline (update from latest release to main). 
## Checklist

- [x] `make generate` re-run if `api/v1/*.go` changed - not changed
- [x] `make test` passes - no code changes
- [x] Docs / CRDs updated if user-facing - no API / code changes
