### PR TITLE
fix: skip no-op Updates when managed fields are unchanged

### DIFF
--- a/controllers/alertmanager/assets/alertmanager.yaml
+++ b/controllers/alertmanager/assets/alertmanager.yaml
@@ -23,9 +23,9 @@ spec:
         topologyKey: "kubernetes.io/hostname"
   alertmanagerConfigNamespaceSelector:
     matchExpressions:
-      - key: openshift.io/cluster-monitoring
-        operator: NotIn
-        values: ["true"]
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values: ["true"]
   alertmanagerConfigSelector: {}
   alertmanagerConfigMatcherStrategy:
     type: OnNamespace

--- a/controllers/alertmanager/assets/alertmanager.yaml
+++ b/controllers/alertmanager/assets/alertmanager.yaml
@@ -27,5 +27,9 @@ spec:
         operator: NotIn
         values: ["true"]
   alertmanagerConfigSelector: {}
+  alertmanagerConfigMatcherStrategy:
+    type: OnNamespace
   image: "prom/alertmanager:v0.19.0"
   replicas: 1
+  portName: web
+  retention: 120h

--- a/controllers/alertmanager/handlers.go
+++ b/controllers/alertmanager/handlers.go
@@ -2,6 +2,7 @@ package alertmanager
 
 import (
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -26,7 +27,10 @@ func (r *AlertManagerReconciler) handleServiceAccount(cr *monv1.PlatformMonitori
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -52,7 +56,10 @@ func (r *AlertManagerReconciler) handleSecret(cr *monv1.PlatformMonitoring) erro
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -78,8 +85,11 @@ func (r *AlertManagerReconciler) handleAlertmanager(cr *monv1.PlatformMonitoring
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -105,9 +115,12 @@ func (r *AlertManagerReconciler) handleService(cr *monv1.PlatformMonitoring) err
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -132,10 +145,13 @@ func (r *AlertManagerReconciler) handleIngressV1(cr *monv1.PlatformMonitoring) e
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -162,11 +178,14 @@ func (r *AlertManagerReconciler) handlePodMonitor(cr *monv1.PlatformMonitoring) 
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.PodMetricsEndpoints = m.Spec.PodMetricsEndpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.PodMetricsEndpoints, m.Spec.PodMetricsEndpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/alertmanager/handlers_skip_test.go
+++ b/controllers/alertmanager/handlers_skip_test.go
@@ -1,0 +1,74 @@
+package alertmanager
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandleAlertmanagerSkipsCRDDefaultedSpec(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := alertmanager(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	applyCRDDefaultedAlertmanagerSpec(&live.Spec)
+
+	r := newAlertmanagerSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleAlertmanager(cr))
+
+	got := &promv1.Alertmanager{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "CRD-defaulted Alertmanager spec must not trigger Update")
+	assert.Equal(t, "web", got.Spec.PortName)
+	assert.Equal(t, "120h", string(got.Spec.Retention))
+}
+
+func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
+	install := true
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			AlertManager: &monv1.AlertManager{
+				Install: &install,
+				Image:   "docker.io/prom/alertmanager:v0.33.1",
+			},
+		},
+	}
+}
+
+func newAlertmanagerSkipTestReconciler(t *testing.T, objs ...client.Object) *AlertManagerReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	return NewAlertManagerReconciler(
+		fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		scheme,
+		nil,
+	)
+}
+
+func applyCRDDefaultedAlertmanagerSpec(spec *promv1.AlertmanagerSpec) {
+	if spec.PortName == "" {
+		spec.PortName = "web"
+	}
+	if spec.Retention == "" {
+		spec.Retention = "120h"
+	}
+	if spec.AlertmanagerConfigMatcherStrategy.Type == "" {
+		spec.AlertmanagerConfigMatcherStrategy.Type = promv1.OnNamespaceConfigMatcherStrategyType
+	}
+}

--- a/controllers/alertmanager/handlers_skip_test.go
+++ b/controllers/alertmanager/handlers_skip_test.go
@@ -32,6 +32,25 @@ func TestHandleAlertmanagerSkipsCRDDefaultedSpec(t *testing.T) {
 	assert.Equal(t, "120h", string(got.Spec.Retention))
 }
 
+func TestHandleAlertmanagerUpdatesChangedSpec(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := alertmanager(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	stale := int32(3)
+	live.Spec.Replicas = &stale
+
+	r := newAlertmanagerSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleAlertmanager(cr))
+
+	got := &promv1.Alertmanager{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "spec change must trigger Update")
+	require.NotNil(t, got.Spec.Replicas)
+	assert.Equal(t, int32(1), *got.Spec.Replicas)
+}
+
 func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
 	install := true
 	return &monv1.PlatformMonitoring{

--- a/controllers/gateway/gateway_routes.go
+++ b/controllers/gateway/gateway_routes.go
@@ -114,9 +114,12 @@ func applyGatewayResource(r *utils.ComponentReconciler, resolver *gatewayAPIReso
 	}
 
 	logHTTPRouteParentStatus(r, current)
-	current.SetLabels(desired.GetLabels())
-	current.SetAnnotations(desired.GetAnnotations())
-	current.Object["spec"] = desired.Object["spec"]
+	changed := utils.SetLabelsIfChanged(current, desired.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(current, desired.GetAnnotations()) || changed
+	changed = utils.SetUnstructuredFieldIfChanged(current.Object, "spec", desired.Object["spec"]) || changed
+	if !changed {
+		return nil
+	}
 	if err := r.Client.Update(context.TODO(), current); err != nil {
 		return err
 	}

--- a/controllers/gateway/gateway_skip_test.go
+++ b/controllers/gateway/gateway_skip_test.go
@@ -69,3 +69,64 @@ func TestApplyGatewayResourceSkipsNoOpUpdate(t *testing.T) {
 	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
 	assert.Equal(t, "1", got.GetResourceVersion(), "no-op reconcile must not bump resourceVersion")
 }
+
+func TestApplyGatewayResourceUpdatesChangedSpec(t *testing.T) {
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+	}
+	cfg := GatewayRouteConfig{
+		NamePrefix:  "grafana",
+		Namespace:   "monitoring",
+		Host:        "grafana.example.com",
+		ServiceName: "grafana",
+		ServicePort: 3000,
+		Labels:      map[string]string{"app.kubernetes.io/name": "grafana"},
+	}
+	desired, err := buildHTTPRoute(cfg, nil, []string{cfg.Host})
+	require.NoError(t, err)
+	gvk := schema.GroupVersionKind{Group: gatewayAPIGroup, Version: "v1", Kind: httpRouteKind}
+	desired.SetGroupVersionKind(gvk)
+	raw, err := desired.MarshalJSON()
+	require.NoError(t, err)
+	require.NoError(t, desired.UnmarshalJSON(raw))
+	desired.SetGroupVersionKind(gvk)
+
+	live := desired.DeepCopy()
+	live.SetResourceVersion("1")
+	require.NoError(t, unstructured.SetNestedStringSlice(live.Object, []string{"stale.example.com"}, "spec", "hostnames"))
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(httpRouteKind+"List"), &unstructured.UnstructuredList{})
+	metav1.AddToGroupVersion(scheme, gvk.GroupVersion())
+
+	r := &utils.ComponentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr, live).Build(),
+		Scheme: scheme,
+		Log:    utils.Logger("gateway_skip_test"),
+	}
+	resolver := &gatewayAPIResolver{
+		r:      r,
+		loaded: true,
+		apiLists: []*metav1.APIResourceList{{
+			GroupVersion: gvk.GroupVersion().String(),
+			APIResources: []metav1.APIResource{{Kind: httpRouteKind, Name: "httproutes"}},
+		}},
+	}
+
+	require.NoError(t, applyGatewayResource(r, resolver, cr, desired.DeepCopy(), gatewayAPIGroup))
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(gvk)
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.GetResourceVersion(), "spec change must trigger Update")
+	hostnames, found, err := unstructured.NestedStringSlice(got.Object, "spec", "hostnames")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, []string{cfg.Host}, hostnames)
+}

--- a/controllers/gateway/gateway_skip_test.go
+++ b/controllers/gateway/gateway_skip_test.go
@@ -1,0 +1,71 @@
+package gateway
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApplyGatewayResourceSkipsNoOpUpdate(t *testing.T) {
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+	}
+	cfg := GatewayRouteConfig{
+		NamePrefix:  "grafana",
+		Namespace:   "monitoring",
+		Host:        "grafana.example.com",
+		ServiceName: "grafana",
+		ServicePort: 3000,
+		Labels:      map[string]string{"app.kubernetes.io/name": "grafana"},
+	}
+	desired, err := buildHTTPRoute(cfg, nil, []string{cfg.Host})
+	require.NoError(t, err)
+	gvk := schema.GroupVersionKind{Group: gatewayAPIGroup, Version: "v1", Kind: httpRouteKind}
+	desired.SetGroupVersionKind(gvk)
+	raw, err := desired.MarshalJSON()
+	require.NoError(t, err)
+	require.NoError(t, desired.UnmarshalJSON(raw))
+	desired.SetGroupVersionKind(gvk)
+	desired.SetResourceVersion("1")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(httpRouteKind+"List"), &unstructured.UnstructuredList{})
+	metav1.AddToGroupVersion(scheme, gvk.GroupVersion())
+
+	r := &utils.ComponentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr, desired.DeepCopy()).Build(),
+		Scheme: scheme,
+		Log:    utils.Logger("gateway_skip_test"),
+	}
+	resolver := &gatewayAPIResolver{
+		r:      r,
+		loaded: true,
+		apiLists: []*metav1.APIResourceList{{
+			GroupVersion: gvk.GroupVersion().String(),
+			APIResources: []metav1.APIResource{{Kind: httpRouteKind, Name: "httproutes"}},
+		}},
+	}
+
+	require.NoError(t, applyGatewayResource(r, resolver, cr, desired.DeepCopy(), gatewayAPIGroup))
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(gvk)
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.GetResourceVersion(), "no-op reconcile must not bump resourceVersion")
+}

--- a/controllers/grafana-operator/handlers.go
+++ b/controllers/grafana-operator/handlers.go
@@ -2,7 +2,6 @@ package grafana_operator
 
 import (
 	"context"
-	"reflect"
 
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
@@ -35,7 +34,10 @@ func (r *GrafanaOperatorReconciler) handleServiceAccount(cr *monv1.PlatformMonit
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -62,9 +64,11 @@ func (r *GrafanaOperatorReconciler) handleClusterRole(cr *monv1.PlatformMonitori
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -90,7 +94,10 @@ func (r *GrafanaOperatorReconciler) handleClusterRoleBinding(cr *monv1.PlatformM
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -117,9 +124,11 @@ func (r *GrafanaOperatorReconciler) handleRole(cr *monv1.PlatformMonitoring) err
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -145,7 +154,10 @@ func (r *GrafanaOperatorReconciler) handleRoleBinding(cr *monv1.PlatformMonitori
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -184,20 +196,24 @@ func (r *GrafanaOperatorReconciler) handleDeployment(cr *monv1.PlatformMonitorin
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
 	if preservedSelector != nil {
-		e.Spec.Selector = preservedSelector
+		changed = utils.SetIfChanged(&e.Spec.Selector, preservedSelector) || changed
 	} else {
-		e.Spec.Selector = m.Spec.Selector
+		changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
 	}
-	e.Spec.Template.Labels = deploymentTemplateLabelsForUpdate(
+	templateLabels := deploymentTemplateLabelsForUpdate(
 		e.Spec.Template.Labels, m.Spec.Template.Labels, e.Spec.Selector)
-	e.Spec.Template.Spec.SecurityContext = m.Spec.Template.Spec.SecurityContext
-	e.Spec.Template.Spec.Containers = m.Spec.Template.Spec.Containers
-	e.Spec.Template.Spec.ServiceAccountName = m.Spec.Template.Spec.ServiceAccountName
-	e.Spec.Template.Spec.NodeSelector = m.Spec.Template.Spec.NodeSelector
-	e.Spec.Template.Spec.Affinity = m.Spec.Template.Spec.Affinity
-	e.Spec.Template.Spec.PriorityClassName = m.Spec.Template.Spec.PriorityClassName
+	changed = utils.SetLabelsIfChanged(&e.Spec.Template, templateLabels) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.SecurityContext, m.Spec.Template.Spec.SecurityContext) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Containers, m.Spec.Template.Spec.Containers) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.ServiceAccountName, m.Spec.Template.Spec.ServiceAccountName) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.NodeSelector, m.Spec.Template.Spec.NodeSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Affinity, m.Spec.Template.Spec.Affinity) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.PriorityClassName, m.Spec.Template.Spec.PriorityClassName) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -229,16 +245,9 @@ func (r *GrafanaOperatorReconciler) handleGrafanaDashboard(fileName string, cr *
 
 		// Only update when Spec or labels actually changed to avoid rewriting large
 		// dashboard CRs on every PlatformMonitoring reconcile (#447).
-		needsUpdate := false
-		if !reflect.DeepEqual(checkObj.Spec, m.Spec) {
-			checkObj.Spec = m.Spec
-			needsUpdate = true
-		}
-		if !reflect.DeepEqual(checkObj.GetLabels(), m.GetLabels()) {
-			checkObj.SetLabels(m.GetLabels())
-			needsUpdate = true
-		}
-		if !needsUpdate {
+		changed := utils.SetIfChanged(&checkObj.Spec, m.Spec)
+		changed = utils.SetLabelsIfChanged(checkObj, m.GetLabels()) || changed
+		if !changed {
 			return nil
 		}
 		return r.UpdateResource(checkObj)
@@ -264,11 +273,14 @@ func (r *GrafanaOperatorReconciler) handlePodMonitor(cr *monv1.PlatformMonitorin
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.PodMetricsEndpoints = m.Spec.PodMetricsEndpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.PodMetricsEndpoints, m.Spec.PodMetricsEndpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/grafana-operator/handlers_test.go
+++ b/controllers/grafana-operator/handlers_test.go
@@ -8,6 +8,8 @@ import (
 	grafv1 "github.com/grafana/grafana-operator/v5/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -111,4 +113,49 @@ func TestHandleGrafanaDashboardUpdatesChangedLabels(t *testing.T) {
 	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
 	assert.Equal(t, desired.GetLabels(), got.GetLabels())
 	assert.NotEqual(t, "1", got.ResourceVersion, "label change must trigger Update")
+}
+
+func newGrafanaOperatorWorkloadTestReconciler(t *testing.T, objs ...client.Object) *GrafanaOperatorReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, grafv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, rbacv1.AddToScheme(scheme))
+	return &GrafanaOperatorReconciler{
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+			Scheme: scheme,
+			Log:    utils.Logger("grafanaoperator_skip_test"),
+		},
+	}
+}
+
+func TestHandleClusterRoleSkipsNoOpUpdate(t *testing.T) {
+	cr := testPlatformMonitoring()
+	desired, err := grafanaOperatorClusterRole(cr)
+	require.NoError(t, err)
+	desired.ResourceVersion = "1"
+
+	r := newGrafanaOperatorWorkloadTestReconciler(t, cr, desired.DeepCopy())
+	require.NoError(t, r.handleClusterRole(cr))
+
+	got := &rbacv1.ClusterRole{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
+}
+
+func TestHandleDeploymentSkipsNoOpUpdateWithPreservedSelector(t *testing.T) {
+	cr := testPlatformMonitoring()
+	desired, err := grafanaOperatorDeployment(cr)
+	require.NoError(t, err)
+	desired.ResourceVersion = "1"
+
+	r := newGrafanaOperatorWorkloadTestReconciler(t, cr, desired.DeepCopy())
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
+	assert.Equal(t, desired.Spec.Selector, got.Spec.Selector)
 }

--- a/controllers/grafana-operator/handlers_test.go
+++ b/controllers/grafana-operator/handlers_test.go
@@ -159,3 +159,22 @@ func TestHandleDeploymentSkipsNoOpUpdateWithPreservedSelector(t *testing.T) {
 	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
 	assert.Equal(t, desired.Spec.Selector, got.Spec.Selector)
 }
+
+func TestHandleDeploymentUpdatesChangedImage(t *testing.T) {
+	cr := testPlatformMonitoring()
+	desired, err := grafanaOperatorDeployment(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	require.NotEmpty(t, live.Spec.Template.Spec.Containers)
+	live.Spec.Template.Spec.Containers[0].Image = "stale:old"
+
+	r := newGrafanaOperatorWorkloadTestReconciler(t, cr, live)
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "image change must trigger Update")
+	require.NotEmpty(t, got.Spec.Template.Spec.Containers)
+	assert.Equal(t, desired.Spec.Template.Spec.Containers[0].Image, got.Spec.Template.Spec.Containers[0].Image)
+}

--- a/controllers/grafana/handlers.go
+++ b/controllers/grafana/handlers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -125,16 +124,9 @@ func (r *GrafanaReconciler) handleGrafana(cr *monv1.PlatformMonitoring) error {
 }
 
 func applyGrafanaDesiredState(existing, desired *grafv1.Grafana) bool {
-	needsUpdate := false
-	if !reflect.DeepEqual(existing.Spec, desired.Spec) {
-		existing.Spec = desired.Spec
-		needsUpdate = true
-	}
-	if !reflect.DeepEqual(existing.GetLabels(), desired.GetLabels()) {
-		existing.SetLabels(desired.GetLabels())
-		needsUpdate = true
-	}
-	return needsUpdate
+	changed := utils.SetIfChanged(&existing.Spec, desired.Spec)
+	changed = utils.SetLabelsIfChanged(existing, desired.GetLabels()) || changed
+	return changed
 }
 
 func (r *GrafanaReconciler) handleGrafanaDataSource(cr *monv1.PlatformMonitoring) error {
@@ -181,20 +173,13 @@ func (r *GrafanaReconciler) handleGrafanaDataSource(cr *monv1.PlatformMonitoring
 	}
 
 	// Only update if something actually changed to avoid unnecessary updates
-	needsUpdate := false
-	if !reflect.DeepEqual(checkObj.Spec, m.Spec) {
-		checkObj.Spec = m.Spec
-		needsUpdate = true
+	changed := utils.SetIfChanged(&checkObj.Spec, m.Spec)
+	changed = utils.SetLabelsIfChanged(checkObj, m.GetLabels()) || changed
+	if !changed {
+		return nil
 	}
-	if !reflect.DeepEqual(checkObj.GetLabels(), m.GetLabels()) {
-		checkObj.SetLabels(m.GetLabels())
-		needsUpdate = true
-	}
-
-	if needsUpdate {
-		if err = r.UpdateResource(checkObj); err != nil {
-			return err
-		}
+	if err = r.UpdateResource(checkObj); err != nil {
+		return err
 	}
 	return nil
 }
@@ -236,20 +221,13 @@ func (r *GrafanaReconciler) handleGrafanaPromxyDataSource(cr *monv1.PlatformMoni
 
 	// Set parameters
 	// Only update if something actually changed to avoid unnecessary updates
-	needsUpdate := false
-	if !reflect.DeepEqual(checkObj.Spec, m.Spec) {
-		checkObj.Spec = m.Spec
-		needsUpdate = true
+	changed := utils.SetIfChanged(&checkObj.Spec, m.Spec)
+	changed = utils.SetLabelsIfChanged(checkObj, m.GetLabels()) || changed
+	if !changed {
+		return nil
 	}
-	if !reflect.DeepEqual(checkObj.GetLabels(), m.GetLabels()) {
-		checkObj.SetLabels(m.GetLabels())
-		needsUpdate = true
-	}
-
-	if needsUpdate {
-		if err = r.UpdateResource(checkObj); err != nil {
-			return err
-		}
+	if err = r.UpdateResource(checkObj); err != nil {
+		return err
 	}
 	return nil
 }
@@ -272,10 +250,13 @@ func (r *GrafanaReconciler) handleIngressV1(cr *monv1.PlatformMonitoring) error 
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -302,11 +283,14 @@ func (r *GrafanaReconciler) handlePodMonitor(cr *monv1.PlatformMonitoring) error
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.PodMetricsEndpoints = m.Spec.PodMetricsEndpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.PodMetricsEndpoints, m.Spec.PodMetricsEndpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/kubernetes-monitors/handlers.go
+++ b/controllers/kubernetes-monitors/handlers.go
@@ -2,6 +2,7 @@ package kubernetes_monitors
 
 import (
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -23,11 +24,14 @@ func (r *KubernetesMonitorsReconciler) handleApiServerServiceMonitor(cr *monv1.P
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.Endpoints = m.Spec.Endpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.Endpoints, m.Spec.Endpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -53,11 +57,14 @@ func (r *KubernetesMonitorsReconciler) handleKubeletServiceMonitor(cr *monv1.Pla
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.Endpoints = m.Spec.Endpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.Endpoints, m.Spec.Endpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -83,11 +90,14 @@ func (r *KubernetesMonitorsReconciler) handleNginxIngressPodMonitor(cr *monv1.Pl
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.PodMetricsEndpoints = m.Spec.PodMetricsEndpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.PodMetricsEndpoints, m.Spec.PodMetricsEndpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -113,11 +123,14 @@ func (r *KubernetesMonitorsReconciler) handleCoreDnsServiceMonitor(cr *monv1.Pla
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.Endpoints = m.Spec.Endpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.Endpoints, m.Spec.Endpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -145,11 +158,14 @@ func (r *KubernetesMonitorsReconciler) handleOpenshiftServiceMonitor(cr *monv1.P
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.Endpoints = m.Spec.Endpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.Endpoints, m.Spec.Endpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/kubernetes-monitors/handlers_skip_test.go
+++ b/controllers/kubernetes-monitors/handlers_skip_test.go
@@ -1,0 +1,45 @@
+package kubernetes_monitors
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandleApiServerServiceMonitorSkipsNoOpUpdate(t *testing.T) {
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+	}
+	desired, err := kubernetesMonitorsApiServerServiceMonitor(cr)
+	require.NoError(t, err)
+	desired.ResourceVersion = "1"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	r := &KubernetesMonitorsReconciler{
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr, desired.DeepCopy()).Build(),
+			Scheme: scheme,
+			Log:    utils.Logger("kubernetes_monitors_skip_test"),
+		},
+	}
+	require.NoError(t, r.handleApiServerServiceMonitor(cr))
+
+	got := &promv1.ServiceMonitor{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
+}

--- a/controllers/kubernetes-monitors/handlers_skip_test.go
+++ b/controllers/kubernetes-monitors/handlers_skip_test.go
@@ -43,3 +43,35 @@ func TestHandleApiServerServiceMonitorSkipsNoOpUpdate(t *testing.T) {
 	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
 	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
 }
+
+func TestHandleApiServerServiceMonitorUpdatesChangedJobLabel(t *testing.T) {
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+	}
+	desired, err := kubernetesMonitorsApiServerServiceMonitor(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	live.Spec.JobLabel = "stale"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	r := &KubernetesMonitorsReconciler{
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr, live).Build(),
+			Scheme: scheme,
+			Log:    utils.Logger("kubernetes_monitors_skip_test"),
+		},
+	}
+	require.NoError(t, r.handleApiServerServiceMonitor(cr))
+
+	got := &promv1.ServiceMonitor{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "JobLabel change must trigger Update")
+	assert.Equal(t, desired.Spec.JobLabel, got.Spec.JobLabel)
+}

--- a/controllers/kubestatemetrics/assets/deployment.yaml
+++ b/controllers/kubestatemetrics/assets/deployment.yaml
@@ -28,11 +28,19 @@ spec:
           ports:
             - name: http-metrics
               containerPort: 8080
+              protocol: TCP
             - name: telemetry
               containerPort: 8081
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8080
+              scheme: HTTP
             initialDelaySeconds: 5
             timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File

--- a/controllers/kubestatemetrics/handlers.go
+++ b/controllers/kubestatemetrics/handlers.go
@@ -28,7 +28,10 @@ func (r *KubeStateMetricsReconciler) handleServiceAccount(cr *monv1.PlatformMoni
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -55,9 +58,11 @@ func (r *KubeStateMetricsReconciler) handleClusterRole(cr *monv1.PlatformMonitor
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -83,7 +88,10 @@ func (r *KubeStateMetricsReconciler) handleClusterRoleBinding(cr *monv1.Platform
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -115,14 +123,17 @@ func (r *KubeStateMetricsReconciler) handleDeployment(cr *monv1.PlatformMonitori
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Template.SetLabels(m.Spec.Template.GetLabels())
-	e.Spec.Template.Spec.SecurityContext = m.Spec.Template.Spec.SecurityContext
-	e.Spec.Template.Spec.Containers = m.Spec.Template.Spec.Containers
-	e.Spec.Template.Spec.ServiceAccountName = m.Spec.Template.Spec.ServiceAccountName
-	e.Spec.Template.Spec.NodeSelector = m.Spec.Template.Spec.NodeSelector
-	e.Spec.Template.Spec.Affinity = m.Spec.Template.Spec.Affinity
-	e.Spec.Template.Spec.PriorityClassName = m.Spec.Template.Spec.PriorityClassName
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetLabelsIfChanged(&e.Spec.Template, m.Spec.Template.GetLabels()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.SecurityContext, m.Spec.Template.Spec.SecurityContext) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Containers, m.Spec.Template.Spec.Containers) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.ServiceAccountName, m.Spec.Template.Spec.ServiceAccountName) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.NodeSelector, m.Spec.Template.Spec.NodeSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Affinity, m.Spec.Template.Spec.Affinity) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.PriorityClassName, m.Spec.Template.Spec.PriorityClassName) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -151,9 +162,12 @@ func (r *KubeStateMetricsReconciler) handleService(cr *monv1.PlatformMonitoring)
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -180,11 +194,14 @@ func (r *KubeStateMetricsReconciler) handleServiceMonitor(cr *monv1.PlatformMoni
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.Endpoints = m.Spec.Endpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.Endpoints, m.Spec.Endpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/kubestatemetrics/handlers_skip_test.go
+++ b/controllers/kubestatemetrics/handlers_skip_test.go
@@ -1,0 +1,98 @@
+package kubestatemetrics
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandleDeploymentSkipsAPIDefaultedContainers(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := kubeStateMetricsDeployment(cr, false)
+	require.NoError(t, err)
+
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	applyAPIDefaultedContainerFields(live.Spec.Template.Spec.Containers)
+	live.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirst
+	live.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
+	live.Spec.Template.Spec.SchedulerName = "default-scheduler"
+
+	r := newKubeStateMetricsSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted container and PodSpec fields must not trigger Update")
+}
+
+func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
+	install := true
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			KubeStateMetrics: &monv1.KubeStateMetrics{
+				Install: &install,
+				Image:   "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0",
+			},
+		},
+	}
+}
+
+func newKubeStateMetricsSkipTestReconciler(t *testing.T, objs ...client.Object) *KubeStateMetricsReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	return NewKubeStateMetricsReconciler(
+		fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		scheme,
+		&fakediscovery.FakeDiscovery{Fake: &k8stesting.Fake{}},
+	)
+}
+
+func applyAPIDefaultedContainerFields(containers []corev1.Container) {
+	for i := range containers {
+		c := &containers[i]
+		for j := range c.Ports {
+			if c.Ports[j].Protocol == "" {
+				c.Ports[j].Protocol = corev1.ProtocolTCP
+			}
+		}
+		if c.TerminationMessagePath == "" {
+			c.TerminationMessagePath = "/dev/termination-log"
+		}
+		if c.TerminationMessagePolicy == "" {
+			c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+		if probe := c.ReadinessProbe; probe != nil {
+			if probe.PeriodSeconds == 0 {
+				probe.PeriodSeconds = 10
+			}
+			if probe.SuccessThreshold == 0 {
+				probe.SuccessThreshold = 1
+			}
+			if probe.FailureThreshold == 0 {
+				probe.FailureThreshold = 3
+			}
+			if probe.HTTPGet != nil && probe.HTTPGet.Scheme == "" {
+				probe.HTTPGet.Scheme = corev1.URISchemeHTTP
+			}
+		}
+	}
+}

--- a/controllers/kubestatemetrics/handlers_skip_test.go
+++ b/controllers/kubestatemetrics/handlers_skip_test.go
@@ -37,6 +37,25 @@ func TestHandleDeploymentSkipsAPIDefaultedContainers(t *testing.T) {
 	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted container and PodSpec fields must not trigger Update")
 }
 
+func TestHandleDeploymentUpdatesChangedImage(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := kubeStateMetricsDeployment(cr, false)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	require.NotEmpty(t, live.Spec.Template.Spec.Containers)
+	live.Spec.Template.Spec.Containers[0].Image = "stale:old"
+
+	r := newKubeStateMetricsSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "image change must trigger Update")
+	require.NotEmpty(t, got.Spec.Template.Spec.Containers)
+	assert.Equal(t, cr.Spec.KubeStateMetrics.Image, got.Spec.Template.Spec.Containers[0].Image)
+}
+
 func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
 	install := true
 	return &monv1.PlatformMonitoring{

--- a/controllers/nodeexporter/assets/daemonset.yaml
+++ b/controllers/nodeexporter/assets/daemonset.yaml
@@ -35,6 +35,9 @@ spec:
             - containerPort: 9900
               hostPort: 9900
               name: metrics
+              protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
           volumeMounts:
             - mountPath: /host
               mountPropagation: HostToContainer
@@ -60,9 +63,11 @@ spec:
       volumes:
         - hostPath:
             path: /proc
+            type: ""
           name: proc
         - hostPath:
             path: /sys
+            type: ""
           name: sys
         - hostPath:
             path: /
@@ -70,6 +75,7 @@ spec:
           name: root
         - hostPath:
             path: /run
+            type: ""
           name: run
         - hostPath:
             path: /var/spool/monitoring

--- a/controllers/nodeexporter/handlers.go
+++ b/controllers/nodeexporter/handlers.go
@@ -31,7 +31,10 @@ func (r *NodeExporterReconciler) handleServiceAccount(cr *monv1.PlatformMonitori
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -61,9 +64,11 @@ func (r *NodeExporterReconciler) handleClusterRole(cr *monv1.PlatformMonitoring)
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -92,7 +97,10 @@ func (r *NodeExporterReconciler) handleClusterRoleBinding(cr *monv1.PlatformMoni
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -126,8 +134,11 @@ func (r *NodeExporterReconciler) handleSecurityContextConstraints(cr *monv1.Plat
 		)
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	applyNodeExporterSCCPolicy(e, m)
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = applyNodeExporterSCCPolicy(e, m) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -141,28 +152,30 @@ func isNodeExporterSCCOwnedBy(scc *secv1.SecurityContextConstraints, cr *monv1.P
 		annotations[nodeExporterSCCOwnerNamespaceAnnotation] == cr.GetNamespace()
 }
 
-func applyNodeExporterSCCPolicy(existing, desired *secv1.SecurityContextConstraints) {
-	existing.AllowPrivilegedContainer = desired.AllowPrivilegedContainer
-	existing.DefaultAddCapabilities = desired.DefaultAddCapabilities
-	existing.RequiredDropCapabilities = desired.RequiredDropCapabilities
-	existing.AllowedCapabilities = desired.AllowedCapabilities
-	existing.AllowHostDirVolumePlugin = desired.AllowHostDirVolumePlugin
-	existing.Volumes = desired.Volumes
-	existing.AllowedFlexVolumes = desired.AllowedFlexVolumes
-	existing.AllowHostNetwork = desired.AllowHostNetwork
-	existing.AllowHostPorts = desired.AllowHostPorts
-	existing.AllowHostPID = desired.AllowHostPID
-	existing.AllowHostIPC = desired.AllowHostIPC
-	existing.DefaultAllowPrivilegeEscalation = desired.DefaultAllowPrivilegeEscalation
-	existing.AllowPrivilegeEscalation = desired.AllowPrivilegeEscalation
-	existing.SELinuxContext = desired.SELinuxContext
-	existing.RunAsUser = desired.RunAsUser
-	existing.SupplementalGroups = desired.SupplementalGroups
-	existing.FSGroup = desired.FSGroup
-	existing.ReadOnlyRootFilesystem = desired.ReadOnlyRootFilesystem
-	existing.SeccompProfiles = desired.SeccompProfiles
-	existing.AllowedUnsafeSysctls = desired.AllowedUnsafeSysctls
-	existing.ForbiddenSysctls = desired.ForbiddenSysctls
+func applyNodeExporterSCCPolicy(existing, desired *secv1.SecurityContextConstraints) bool {
+	changed := false
+	changed = utils.SetIfChanged(&existing.AllowPrivilegedContainer, desired.AllowPrivilegedContainer) || changed
+	changed = utils.SetIfChanged(&existing.DefaultAddCapabilities, desired.DefaultAddCapabilities) || changed
+	changed = utils.SetIfChanged(&existing.RequiredDropCapabilities, desired.RequiredDropCapabilities) || changed
+	changed = utils.SetIfChanged(&existing.AllowedCapabilities, desired.AllowedCapabilities) || changed
+	changed = utils.SetIfChanged(&existing.AllowHostDirVolumePlugin, desired.AllowHostDirVolumePlugin) || changed
+	changed = utils.SetIfChanged(&existing.Volumes, desired.Volumes) || changed
+	changed = utils.SetIfChanged(&existing.AllowedFlexVolumes, desired.AllowedFlexVolumes) || changed
+	changed = utils.SetIfChanged(&existing.AllowHostNetwork, desired.AllowHostNetwork) || changed
+	changed = utils.SetIfChanged(&existing.AllowHostPorts, desired.AllowHostPorts) || changed
+	changed = utils.SetIfChanged(&existing.AllowHostPID, desired.AllowHostPID) || changed
+	changed = utils.SetIfChanged(&existing.AllowHostIPC, desired.AllowHostIPC) || changed
+	changed = utils.SetIfChanged(&existing.DefaultAllowPrivilegeEscalation, desired.DefaultAllowPrivilegeEscalation) || changed
+	changed = utils.SetIfChanged(&existing.AllowPrivilegeEscalation, desired.AllowPrivilegeEscalation) || changed
+	changed = utils.SetIfChanged(&existing.SELinuxContext, desired.SELinuxContext) || changed
+	changed = utils.SetIfChanged(&existing.RunAsUser, desired.RunAsUser) || changed
+	changed = utils.SetIfChanged(&existing.SupplementalGroups, desired.SupplementalGroups) || changed
+	changed = utils.SetIfChanged(&existing.FSGroup, desired.FSGroup) || changed
+	changed = utils.SetIfChanged(&existing.ReadOnlyRootFilesystem, desired.ReadOnlyRootFilesystem) || changed
+	changed = utils.SetIfChanged(&existing.SeccompProfiles, desired.SeccompProfiles) || changed
+	changed = utils.SetIfChanged(&existing.AllowedUnsafeSysctls, desired.AllowedUnsafeSysctls) || changed
+	changed = utils.SetIfChanged(&existing.ForbiddenSysctls, desired.ForbiddenSysctls) || changed
+	return changed
 }
 
 func (r *NodeExporterReconciler) deleteSecurityContextConstraints(cr *monv1.PlatformMonitoring) error {
@@ -214,9 +227,12 @@ func (r *NodeExporterReconciler) handleDaemonSet(cr *monv1.PlatformMonitoring) e
 		return r.CreateResource(cr, m)
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Template.SetLabels(m.Spec.Template.GetLabels())
-	e.Spec.Template.Spec = m.Spec.Template.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetLabelsIfChanged(&e.Spec.Template, m.Spec.Template.GetLabels()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec, m.Spec.Template.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -245,9 +261,12 @@ func (r *NodeExporterReconciler) handleService(cr *monv1.PlatformMonitoring) err
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -274,11 +293,14 @@ func (r *NodeExporterReconciler) handleServiceMonitor(cr *monv1.PlatformMonitori
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.Endpoints = m.Spec.Endpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.Endpoints, m.Spec.Endpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/nodeexporter/handlers.go
+++ b/controllers/nodeexporter/handlers.go
@@ -226,10 +226,21 @@ func (r *NodeExporterReconciler) handleDaemonSet(cr *monv1.PlatformMonitoring) e
 		}
 		return r.CreateResource(cr, m)
 	}
-	//Set parameters
+	// Set only fields this controller writes. Copying the whole PodSpec would
+	// overwrite API-defaulted values (dnsPolicy, restartPolicy, schedulerName,
+	// terminationGracePeriodSeconds, deprecated serviceAccount) every cycle.
 	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
 	changed = utils.SetLabelsIfChanged(&e.Spec.Template, m.Spec.Template.GetLabels()) || changed
-	changed = utils.SetIfChanged(&e.Spec.Template.Spec, m.Spec.Template.Spec) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.SecurityContext, m.Spec.Template.Spec.SecurityContext) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Containers, m.Spec.Template.Spec.Containers) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Volumes, m.Spec.Template.Spec.Volumes) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.ServiceAccountName, m.Spec.Template.Spec.ServiceAccountName) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.NodeSelector, m.Spec.Template.Spec.NodeSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Affinity, m.Spec.Template.Spec.Affinity) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.PriorityClassName, m.Spec.Template.Spec.PriorityClassName) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Tolerations, m.Spec.Template.Spec.Tolerations) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.HostNetwork, m.Spec.Template.Spec.HostNetwork) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.HostPID, m.Spec.Template.Spec.HostPID) || changed
 	if !changed {
 		return nil
 	}

--- a/controllers/nodeexporter/handlers_skip_test.go
+++ b/controllers/nodeexporter/handlers_skip_test.go
@@ -52,6 +52,25 @@ func TestHandleDaemonSetSkipsAPIDefaultedPodSpec(t *testing.T) {
 	assert.Equal(t, "default-scheduler", got.Spec.Template.Spec.SchedulerName)
 }
 
+func TestHandleDaemonSetUpdatesChangedImage(t *testing.T) {
+	cr := newNodeExporterPlatformMonitoring(true)
+	desired, err := nodeExporterDaemonSet(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	require.NotEmpty(t, live.Spec.Template.Spec.Containers)
+	live.Spec.Template.Spec.Containers[0].Image = "stale:old"
+	live.ResourceVersion = "1"
+
+	r, kubeClient := newNodeExporterTestReconciler(t, false, cr, live)
+	require.NoError(t, r.handleDaemonSet(cr))
+
+	got := &appsv1.DaemonSet{}
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "image change must trigger Update")
+	require.NotEmpty(t, got.Spec.Template.Spec.Containers)
+	assert.Equal(t, cr.Spec.NodeExporter.Image, got.Spec.Template.Spec.Containers[0].Image)
+}
+
 func applyAPIDefaultedPodSpec(spec *corev1.PodSpec) {
 	if spec.DNSPolicy == "" {
 		spec.DNSPolicy = corev1.DNSClusterFirst

--- a/controllers/nodeexporter/handlers_skip_test.go
+++ b/controllers/nodeexporter/handlers_skip_test.go
@@ -1,0 +1,110 @@
+package nodeexporter
+
+import (
+	"encoding/json"
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestHandleDaemonSetSkipsAPIDefaultedPodSpec(t *testing.T) {
+	cr := newNodeExporterPlatformMonitoring(true)
+	cr.Spec.NodeExporter.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("50Mi"),
+		},
+	}
+	runAsUser, fsGroup := int64(2000), int64(2000)
+	cr.Spec.NodeExporter.SecurityContext = &monv1.SecurityContext{
+		RunAsUser: &runAsUser,
+		FSGroup:   &fsGroup,
+	}
+
+	desired, err := nodeExporterDaemonSet(cr)
+	require.NoError(t, err)
+
+	live := desired.DeepCopy()
+	applyAPIDefaultedPodSpec(&live.Spec.Template.Spec)
+	raw, err := json.Marshal(live)
+	require.NoError(t, err)
+	live = &appsv1.DaemonSet{}
+	require.NoError(t, json.Unmarshal(raw, live))
+	live.ResourceVersion = "1"
+
+	r, kubeClient := newNodeExporterTestReconciler(t, false, cr, live)
+	require.NoError(t, r.handleDaemonSet(cr))
+
+	got := &appsv1.DaemonSet{}
+	require.NoError(t, kubeClient.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted PodSpec fields must not trigger Update")
+	assert.Equal(t, corev1.DNSClusterFirst, got.Spec.Template.Spec.DNSPolicy)
+	assert.Equal(t, "default-scheduler", got.Spec.Template.Spec.SchedulerName)
+}
+
+func applyAPIDefaultedPodSpec(spec *corev1.PodSpec) {
+	if spec.DNSPolicy == "" {
+		spec.DNSPolicy = corev1.DNSClusterFirst
+	}
+	if spec.RestartPolicy == "" {
+		spec.RestartPolicy = corev1.RestartPolicyAlways
+	}
+	if spec.SchedulerName == "" {
+		spec.SchedulerName = "default-scheduler"
+	}
+	if spec.TerminationGracePeriodSeconds == nil {
+		tgs := int64(30)
+		spec.TerminationGracePeriodSeconds = &tgs
+	}
+	if spec.DeprecatedServiceAccount == "" {
+		spec.DeprecatedServiceAccount = spec.ServiceAccountName
+	}
+	for i := range spec.Volumes {
+		if hp := spec.Volumes[i].HostPath; hp != nil && hp.Type == nil {
+			t := corev1.HostPathUnset
+			hp.Type = &t
+		}
+	}
+	applyAPIDefaultedContainerFields(spec.Containers)
+}
+
+func applyAPIDefaultedContainerFields(containers []corev1.Container) {
+	for i := range containers {
+		c := &containers[i]
+		for j := range c.Ports {
+			if c.Ports[j].Protocol == "" {
+				c.Ports[j].Protocol = corev1.ProtocolTCP
+			}
+		}
+		if c.TerminationMessagePath == "" {
+			c.TerminationMessagePath = "/dev/termination-log"
+		}
+		if c.TerminationMessagePolicy == "" {
+			c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+		if probe := c.ReadinessProbe; probe != nil {
+			if probe.PeriodSeconds == 0 {
+				probe.PeriodSeconds = 10
+			}
+			if probe.SuccessThreshold == 0 {
+				probe.SuccessThreshold = 1
+			}
+			if probe.FailureThreshold == 0 {
+				probe.FailureThreshold = 3
+			}
+			if probe.HTTPGet != nil && probe.HTTPGet.Scheme == "" {
+				probe.HTTPGet.Scheme = corev1.URISchemeHTTP
+			}
+		}
+	}
+}

--- a/controllers/nodeexporter/securitycontextconstraints_test.go
+++ b/controllers/nodeexporter/securitycontextconstraints_test.go
@@ -171,6 +171,7 @@ func TestHandleSecurityContextConstraints(t *testing.T) {
 		platformMonitoring := newNodeExporterPlatformMonitoring(true)
 		existing, err := nodeExporterSecurityContextConstraints(platformMonitoring)
 		require.NoError(t, err)
+		existing.AllowHostNetwork = false
 		reconciler, kubeClient := newNodeExporterTestReconciler(t, true, existing)
 		expectedErr := errors.New("update SCC")
 		reconciler.Client = interceptNodeExporterClient(t, kubeClient, interceptor.Funcs{

--- a/controllers/prometheus-operator/assets/deployment.yaml
+++ b/controllers/prometheus-operator/assets/deployment.yaml
@@ -26,6 +26,7 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+              protocol: TCP
           resources:
             limits:
               cpu: 200m
@@ -34,7 +35,9 @@ spec:
               cpu: 100m
               memory: 100Mi
           terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
+      securityContext: {}
       serviceAccountName: monitoring-prometheus-operator

--- a/controllers/prometheus-operator/assets/service.yaml
+++ b/controllers/prometheus-operator/assets/service.yaml
@@ -13,5 +13,6 @@ spec:
     - name: http
       port: 8080
       targetPort: http
+      protocol: TCP
   selector:
     app.kubernetes.io/name: prometheus-operator

--- a/controllers/prometheus-operator/handlers.go
+++ b/controllers/prometheus-operator/handlers.go
@@ -29,9 +29,11 @@ func (r *PrometheusOperatorReconciler) handleRole(cr *monv1.PlatformMonitoring) 
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -58,7 +60,10 @@ func (r *PrometheusOperatorReconciler) handleServiceAccount(cr *monv1.PlatformMo
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -85,7 +90,10 @@ func (r *PrometheusOperatorReconciler) handleRoleBinding(cr *monv1.PlatformMonit
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -112,9 +120,11 @@ func (r *PrometheusOperatorReconciler) handleClusterRole(cr *monv1.PlatformMonit
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -141,7 +151,10 @@ func (r *PrometheusOperatorReconciler) handleClusterRoleBinding(cr *monv1.Platfo
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -173,16 +186,19 @@ func (r *PrometheusOperatorReconciler) handleDeployment(cr *monv1.PlatformMonito
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Selector = m.Spec.Selector
-	e.Spec.Template.SetLabels(m.Spec.Template.GetLabels())
-	e.Spec.Template.Spec.SecurityContext = m.Spec.Template.Spec.SecurityContext
-	e.Spec.Template.Spec.Containers = m.Spec.Template.Spec.Containers
-	e.Spec.Template.Spec.ServiceAccountName = m.Spec.Template.Spec.ServiceAccountName
-	e.Spec.Template.Spec.NodeSelector = m.Spec.Template.Spec.NodeSelector
-	e.Spec.Template.Spec.Affinity = m.Spec.Template.Spec.Affinity
-	e.Spec.Template.Spec.Tolerations = m.Spec.Template.Spec.Tolerations
-	e.Spec.Template.Spec.PriorityClassName = m.Spec.Template.Spec.PriorityClassName
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	changed = utils.SetLabelsIfChanged(&e.Spec.Template, m.Spec.Template.GetLabels()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.SecurityContext, m.Spec.Template.Spec.SecurityContext) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Containers, m.Spec.Template.Spec.Containers) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.ServiceAccountName, m.Spec.Template.Spec.ServiceAccountName) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.NodeSelector, m.Spec.Template.Spec.NodeSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Affinity, m.Spec.Template.Spec.Affinity) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Tolerations, m.Spec.Template.Spec.Tolerations) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.PriorityClassName, m.Spec.Template.Spec.PriorityClassName) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -211,9 +227,12 @@ func (r *PrometheusOperatorReconciler) handleService(cr *monv1.PlatformMonitorin
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -240,11 +259,14 @@ func (r *PrometheusOperatorReconciler) handlePodMonitor(cr *monv1.PlatformMonito
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.PodMetricsEndpoints = m.Spec.PodMetricsEndpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.PodMetricsEndpoints, m.Spec.PodMetricsEndpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/prometheus-operator/handlers_skip_test.go
+++ b/controllers/prometheus-operator/handlers_skip_test.go
@@ -54,6 +54,47 @@ func TestHandleDeploymentSkipsAPIDefaultedContainers(t *testing.T) {
 	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted container fields must not trigger Update")
 }
 
+func TestHandleServiceUpdatesChangedPort(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := prometheusOperatorService(cr)
+	require.NoError(t, err)
+	desired.Spec.Selector = map[string]string{
+		"app.kubernetes.io/name": utils.TruncLabel(utils.PrometheusOperatorComponentName),
+	}
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	require.NotEmpty(t, live.Spec.Ports)
+	live.Spec.Ports[0].Port = 9999
+
+	r := newPrometheusOperatorSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleService(cr))
+
+	got := &corev1.Service{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "port change must trigger Update")
+	require.NotEmpty(t, got.Spec.Ports)
+	assert.Equal(t, int32(8080), got.Spec.Ports[0].Port)
+}
+
+func TestHandleDeploymentUpdatesChangedImage(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := prometheusOperatorDeployment(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	require.NotEmpty(t, live.Spec.Template.Spec.Containers)
+	live.Spec.Template.Spec.Containers[0].Image = "stale:old"
+
+	r := newPrometheusOperatorSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "image change must trigger Update")
+	require.NotEmpty(t, got.Spec.Template.Spec.Containers)
+	assert.Equal(t, cr.Spec.Prometheus.Operator.Image, got.Spec.Template.Spec.Containers[0].Image)
+}
+
 func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
 	install := true
 	return &monv1.PlatformMonitoring{

--- a/controllers/prometheus-operator/handlers_skip_test.go
+++ b/controllers/prometheus-operator/handlers_skip_test.go
@@ -1,0 +1,113 @@
+package prometheus_operator
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandleServiceSkipsAPIDefaultedPortProtocol(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := prometheusOperatorService(cr)
+	require.NoError(t, err)
+	desired.Spec.Selector = map[string]string{
+		"app.kubernetes.io/name": utils.TruncLabel(utils.PrometheusOperatorComponentName),
+	}
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	applyAPIDefaultedServicePorts(live.Spec.Ports)
+
+	r := newPrometheusOperatorSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleService(cr))
+
+	got := &corev1.Service{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted Service port protocol must not trigger Update")
+	require.NotEmpty(t, got.Spec.Ports)
+	assert.Equal(t, corev1.ProtocolTCP, got.Spec.Ports[0].Protocol)
+}
+
+func TestHandleDeploymentSkipsAPIDefaultedContainers(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := prometheusOperatorDeployment(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	live.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
+	applyAPIDefaultedContainerFields(live.Spec.Template.Spec.Containers)
+
+	r := newPrometheusOperatorSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted container fields must not trigger Update")
+}
+
+func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
+	install := true
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Prometheus: &monv1.Prometheus{
+				Install:             &install,
+				Image:               "docker.io/prom/prometheus:v3.13.1",
+				ConfigReloaderImage: "quay.io/prometheus-operator/prometheus-config-reloader:v0.93.0",
+				Operator: monv1.PrometheusOperator{
+					Image: "quay.io/prometheus-operator/prometheus-operator:v0.93.0",
+				},
+			},
+		},
+	}
+}
+
+func newPrometheusOperatorSkipTestReconciler(t *testing.T, objs ...client.Object) *PrometheusOperatorReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return NewPrometheusOperatorReconciler(
+		fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		scheme,
+	)
+}
+
+func applyAPIDefaultedServicePorts(ports []corev1.ServicePort) {
+	for i := range ports {
+		if ports[i].Protocol == "" {
+			ports[i].Protocol = corev1.ProtocolTCP
+		}
+	}
+}
+
+func applyAPIDefaultedContainerFields(containers []corev1.Container) {
+	for i := range containers {
+		c := &containers[i]
+		for j := range c.Ports {
+			if c.Ports[j].Protocol == "" {
+				c.Ports[j].Protocol = corev1.ProtocolTCP
+			}
+		}
+		if c.TerminationMessagePath == "" {
+			c.TerminationMessagePath = "/dev/termination-log"
+		}
+		if c.TerminationMessagePolicy == "" {
+			c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+	}
+}

--- a/controllers/prometheus-rules/handlers.go
+++ b/controllers/prometheus-rules/handlers.go
@@ -2,6 +2,7 @@ package prometheus_rules
 
 import (
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -25,8 +26,11 @@ func (r *PrometheusRulesReconciler) handlePrometheusRules(cr *monv1.PlatformMoni
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/prometheus-rules/handlers_skip_test.go
+++ b/controllers/prometheus-rules/handlers_skip_test.go
@@ -1,0 +1,76 @@
+package prometheus_rules
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
+	install := true
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			PrometheusRules: &monv1.PrometheusRules{
+				Install:    &install,
+				RuleGroups: []string{"SelfMonitoring"},
+			},
+		},
+	}
+}
+
+func newPrometheusRulesSkipTestReconciler(t *testing.T, objs ...client.Object) *PrometheusRulesReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	return NewPrometheusRulesReconciler(
+		fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		scheme,
+	)
+}
+
+func TestHandlePrometheusRulesSkipsNoOpUpdate(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := prometheusRules(cr)
+	require.NoError(t, err)
+	desired.ResourceVersion = "1"
+
+	r := newPrometheusRulesSkipTestReconciler(t, cr, desired.DeepCopy())
+	require.NoError(t, r.handlePrometheusRules(cr))
+
+	got := &promv1.PrometheusRule{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
+}
+
+func TestHandlePrometheusRulesUpdatesChangedSpec(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := prometheusRules(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	require.NotEmpty(t, live.Spec.Groups)
+	live.Spec.Groups[0].Name = "stale"
+
+	r := newPrometheusRulesSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handlePrometheusRules(cr))
+
+	got := &promv1.PrometheusRule{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "spec change must trigger Update")
+	require.NotEmpty(t, got.Spec.Groups)
+	assert.Equal(t, desired.Spec.Groups[0].Name, got.Spec.Groups[0].Name)
+}

--- a/controllers/prometheus/assets/prometheus.yaml
+++ b/controllers/prometheus/assets/prometheus.yaml
@@ -36,6 +36,9 @@ spec:
   enableAdminAPI: false
   serviceAccountName: monitoring-prometheus
   externalLabels: {}
+  scrapeInterval: 30s
+  evaluationInterval: 30s
+  portName: web
   ruleNamespaceSelector:
     matchExpressions:
       - key: openshift.io/cluster-monitoring

--- a/controllers/prometheus/assets/prometheus.yaml
+++ b/controllers/prometheus/assets/prometheus.yaml
@@ -41,25 +41,25 @@ spec:
   portName: web
   ruleNamespaceSelector:
     matchExpressions:
-      - key: openshift.io/cluster-monitoring
-        operator: NotIn
-        values: ["true"]
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values: ["true"]
   ruleSelector: {}
   podMonitorNamespaceSelector:
     matchExpressions:
-      - key: openshift.io/cluster-monitoring
-        operator: NotIn
-        values: ["true"]
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values: ["true"]
   podMonitorSelector: {}
   probeNamespaceSelector:
     matchExpressions:
-      - key: openshift.io/cluster-monitoring
-        operator: NotIn
-        values: ["true"]
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values: ["true"]
   probeSelector: {}
   serviceMonitorNamespaceSelector:
     matchExpressions:
-      - key: openshift.io/cluster-monitoring
-        operator: NotIn
-        values: ["true"]
+    - key: openshift.io/cluster-monitoring
+      operator: NotIn
+      values: ["true"]
   serviceMonitorSelector: {}

--- a/controllers/prometheus/handlers.go
+++ b/controllers/prometheus/handlers.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -27,7 +28,10 @@ func (r *PrometheusReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -54,9 +58,11 @@ func (r *PrometheusReconciler) handleClusterRole(cr *monv1.PlatformMonitoring) e
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -82,7 +88,10 @@ func (r *PrometheusReconciler) handleClusterRoleBinding(cr *monv1.PlatformMonito
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -108,8 +117,11 @@ func (r *PrometheusReconciler) handlePrometheus(cr *monv1.PlatformMonitoring) er
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -135,10 +147,13 @@ func (r *PrometheusReconciler) handleIngressV1(cr *monv1.PlatformMonitoring) err
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -165,11 +180,14 @@ func (r *PrometheusReconciler) handlePodMonitor(cr *monv1.PlatformMonitoring) er
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.PodMetricsEndpoints = m.Spec.PodMetricsEndpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.PodMetricsEndpoints, m.Spec.PodMetricsEndpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/prometheus/handlers_skip_test.go
+++ b/controllers/prometheus/handlers_skip_test.go
@@ -33,6 +33,23 @@ func TestHandlePrometheusSkipsCRDDefaultedSpec(t *testing.T) {
 	assert.Equal(t, "web", got.Spec.PortName)
 }
 
+func TestHandlePrometheusUpdatesChangedSpec(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := prometheus(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	live.Spec.ScrapeInterval = "15s"
+
+	r := newPrometheusSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handlePrometheus(cr))
+
+	got := &promv1.Prometheus{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "spec change must trigger Update")
+	assert.Equal(t, promv1.Duration("30s"), got.Spec.ScrapeInterval)
+}
+
 func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
 	install := true
 	return &monv1.PlatformMonitoring{

--- a/controllers/prometheus/handlers_skip_test.go
+++ b/controllers/prometheus/handlers_skip_test.go
@@ -1,0 +1,85 @@
+package prometheus
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandlePrometheusSkipsCRDDefaultedSpec(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := prometheus(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	applyCRDDefaultedPrometheusSpec(&live.Spec)
+
+	r := newPrometheusSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handlePrometheus(cr))
+
+	got := &promv1.Prometheus{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "CRD-defaulted Prometheus spec must not trigger Update")
+	assert.Equal(t, promv1.Duration("30s"), got.Spec.ScrapeInterval)
+	assert.Equal(t, "web", got.Spec.PortName)
+}
+
+func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
+	install := true
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Prometheus: &monv1.Prometheus{
+				Install:             &install,
+				Image:               "docker.io/prom/prometheus:v3.13.1",
+				ConfigReloaderImage: "quay.io/prometheus-operator/prometheus-config-reloader:v0.93.0",
+				Operator: monv1.PrometheusOperator{
+					Image: "quay.io/prometheus-operator/prometheus-operator:v0.93.0",
+				},
+			},
+			AlertManager: &monv1.AlertManager{
+				Install: &install,
+				Image:   "docker.io/prom/alertmanager:v0.33.1",
+			},
+		},
+	}
+}
+
+func newPrometheusSkipTestReconciler(t *testing.T, objs ...client.Object) *PrometheusReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+	return &PrometheusReconciler{
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+			Scheme: scheme,
+			Log:    utils.Logger("prometheus_skip_test"),
+		},
+	}
+}
+
+func applyCRDDefaultedPrometheusSpec(spec *promv1.PrometheusSpec) {
+	if spec.ScrapeInterval == "" {
+		spec.ScrapeInterval = "30s"
+	}
+	if spec.EvaluationInterval == "" {
+		spec.EvaluationInterval = "30s"
+	}
+	if spec.PortName == "" {
+		spec.PortName = "web"
+	}
+}

--- a/controllers/pushgateway/assets/deployment.yaml
+++ b/controllers/pushgateway/assets/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/component: pushgateway
     app.kubernetes.io/part-of: monitoring
     app.kubernetes.io/managed-by: monitoring-operator
-  annotations: {}
   name: pushgateway
 spec:
   replicas: 1
@@ -20,7 +19,6 @@ spec:
         app.kubernetes.io/part-of: monitoring
         app.kubernetes.io/managed-by: monitoring-operator
         app.kubernetes.io/name: pushgateway
-      annotations: {}
     spec:
       containers:
         - name: pushgateway
@@ -34,11 +32,22 @@ spec:
             httpGet:
               path: /-/healthy
               port: 9091
+              scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /-/ready
               port: 9091
+              scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      securityContext: {}

--- a/controllers/pushgateway/handlers.go
+++ b/controllers/pushgateway/handlers.go
@@ -1,6 +1,8 @@
 package pushgateway
 
 import (
+	"maps"
+
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -36,8 +38,8 @@ func (r *PushgatewayReconciler) handleDeployment(cr *monv1.PlatformMonitoring) e
 	//Set parameters
 	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
 	changed = utils.SetLabelsIfChanged(&e.Spec.Template, m.Spec.Template.GetLabels()) || changed
-	changed = utils.SetManagedAnnotationsIfChanged(e, m.GetAnnotations()) || changed
-	changed = utils.SetManagedAnnotationsIfChanged(&e.Spec.Template, m.Spec.Template.GetAnnotations()) || changed
+	changed = utils.SetAnnotationsIfChanged(e, annotationsForDeploymentUpdate(e.GetAnnotations(), m.GetAnnotations())) || changed
+	changed = utils.SetAnnotationsIfChanged(&e.Spec.Template, m.Spec.Template.GetAnnotations()) || changed
 	changed = utils.SetIfChanged(&e.Spec.Template.Spec.SecurityContext, m.Spec.Template.Spec.SecurityContext) || changed
 	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Containers, m.Spec.Template.Spec.Containers) || changed
 	changed = utils.SetIfChanged(&e.Spec.Template.Spec.ServiceAccountName, m.Spec.Template.Spec.ServiceAccountName) || changed
@@ -53,6 +55,23 @@ func (r *PushgatewayReconciler) handleDeployment(cr *monv1.PlatformMonitoring) e
 		return err
 	}
 	return nil
+}
+
+const deploymentRevisionAnnotation = "deployment.kubernetes.io/revision"
+
+// annotationsForDeploymentUpdate keeps full-replace semantics for controller-owned
+// annotations (including removal) while copying kube's revision so idle skip holds.
+func annotationsForDeploymentUpdate(live, desired map[string]string) map[string]string {
+	ann := maps.Clone(desired)
+	rev, ok := live[deploymentRevisionAnnotation]
+	if !ok {
+		return ann
+	}
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	ann[deploymentRevisionAnnotation] = rev
+	return ann
 }
 
 func (r *PushgatewayReconciler) handlePVC(cr *monv1.PlatformMonitoring) error {

--- a/controllers/pushgateway/handlers.go
+++ b/controllers/pushgateway/handlers.go
@@ -34,17 +34,20 @@ func (r *PushgatewayReconciler) handleDeployment(cr *monv1.PlatformMonitoring) e
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Template.SetLabels(m.Spec.Template.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Template.SetAnnotations(m.Spec.Template.GetAnnotations())
-	e.Spec.Template.Spec.SecurityContext = m.Spec.Template.Spec.SecurityContext
-	e.Spec.Template.Spec.Containers = m.Spec.Template.Spec.Containers
-	e.Spec.Template.Spec.ServiceAccountName = m.Spec.Template.Spec.ServiceAccountName
-	e.Spec.Template.Spec.NodeSelector = m.Spec.Template.Spec.NodeSelector
-	e.Spec.Template.Spec.Affinity = m.Spec.Template.Spec.Affinity
-	e.Spec.Replicas = m.Spec.Replicas
-	e.Spec.Template.Spec.PriorityClassName = m.Spec.Template.Spec.PriorityClassName
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetLabelsIfChanged(&e.Spec.Template, m.Spec.Template.GetLabels()) || changed
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetAnnotationsIfChanged(&e.Spec.Template, m.Spec.Template.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.SecurityContext, m.Spec.Template.Spec.SecurityContext) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Containers, m.Spec.Template.Spec.Containers) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.ServiceAccountName, m.Spec.Template.Spec.ServiceAccountName) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.NodeSelector, m.Spec.Template.Spec.NodeSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Affinity, m.Spec.Template.Spec.Affinity) || changed
+	changed = utils.SetIfChanged(&e.Spec.Replicas, m.Spec.Replicas) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.PriorityClassName, m.Spec.Template.Spec.PriorityClassName) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -92,9 +95,12 @@ func (r *PushgatewayReconciler) handleService(cr *monv1.PlatformMonitoring) erro
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -120,10 +126,13 @@ func (r *PushgatewayReconciler) handleIngressV1(cr *monv1.PlatformMonitoring) er
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -150,11 +159,14 @@ func (r *PushgatewayReconciler) handleServiceMonitor(cr *monv1.PlatformMonitorin
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.Endpoints = m.Spec.Endpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.Endpoints, m.Spec.Endpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/pushgateway/handlers.go
+++ b/controllers/pushgateway/handlers.go
@@ -36,8 +36,8 @@ func (r *PushgatewayReconciler) handleDeployment(cr *monv1.PlatformMonitoring) e
 	//Set parameters
 	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
 	changed = utils.SetLabelsIfChanged(&e.Spec.Template, m.Spec.Template.GetLabels()) || changed
-	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
-	changed = utils.SetAnnotationsIfChanged(&e.Spec.Template, m.Spec.Template.GetAnnotations()) || changed
+	changed = utils.SetManagedAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetManagedAnnotationsIfChanged(&e.Spec.Template, m.Spec.Template.GetAnnotations()) || changed
 	changed = utils.SetIfChanged(&e.Spec.Template.Spec.SecurityContext, m.Spec.Template.Spec.SecurityContext) || changed
 	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Containers, m.Spec.Template.Spec.Containers) || changed
 	changed = utils.SetIfChanged(&e.Spec.Template.Spec.ServiceAccountName, m.Spec.Template.Spec.ServiceAccountName) || changed

--- a/controllers/pushgateway/handlers_skip_test.go
+++ b/controllers/pushgateway/handlers_skip_test.go
@@ -37,6 +37,45 @@ func TestHandleDeploymentSkipsAPIDefaultedContainers(t *testing.T) {
 	assert.Equal(t, int32(0), got.Spec.Template.Spec.Containers[0].Ports[0].HostPort)
 }
 
+func TestHandleDeploymentUpdatesChangedReplicas(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := pushgatewayDeployment(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	stale := int32(5)
+	live.Spec.Replicas = &stale
+
+	r := newPushgatewaySkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "replica change must trigger Update")
+	require.NotNil(t, got.Spec.Replicas)
+	assert.Equal(t, int32(1), *got.Spec.Replicas)
+}
+
+func TestHandleDeploymentRemovesDroppedAnnotationsAndKeepsRevision(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := pushgatewayDeployment(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	live.SetAnnotations(map[string]string{
+		"deployment.kubernetes.io/revision": "1",
+		"example.com/stale":                 "drop-me",
+	})
+
+	r := newPushgatewaySkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "removed CR annotation must trigger Update")
+	assert.Equal(t, map[string]string{"deployment.kubernetes.io/revision": "1"}, got.GetAnnotations())
+}
+
 func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
 	install := true
 	return &monv1.PlatformMonitoring{

--- a/controllers/pushgateway/handlers_skip_test.go
+++ b/controllers/pushgateway/handlers_skip_test.go
@@ -1,0 +1,104 @@
+package pushgateway
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandleDeploymentSkipsAPIDefaultedContainers(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := pushgatewayDeployment(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	live.SetAnnotations(map[string]string{"deployment.kubernetes.io/revision": "1"})
+	live.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{}
+	applyAPIDefaultedContainerFields(live.Spec.Template.Spec.Containers)
+
+	r := newPushgatewaySkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleDeployment(cr))
+
+	got := &appsv1.Deployment{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted container fields must not trigger Update")
+	assert.Equal(t, map[string]string{"deployment.kubernetes.io/revision": "1"}, got.GetAnnotations())
+	require.NotEmpty(t, got.Spec.Template.Spec.Containers)
+	assert.Equal(t, int32(0), got.Spec.Template.Spec.Containers[0].Ports[0].HostPort)
+}
+
+func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
+	install := true
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Pushgateway: &monv1.Pushgateway{
+				Install: &install,
+				Image:   "docker.io/prom/pushgateway:v1.11.2",
+				Port:    9091,
+			},
+		},
+	}
+}
+
+func newPushgatewaySkipTestReconciler(t *testing.T, objs ...client.Object) *PushgatewayReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	return &PushgatewayReconciler{
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+			Scheme: scheme,
+			Log:    utils.Logger("pushgateway_skip_test"),
+		},
+	}
+}
+
+func applyAPIDefaultedContainerFields(containers []corev1.Container) {
+	for i := range containers {
+		c := &containers[i]
+		for j := range c.Ports {
+			if c.Ports[j].Protocol == "" {
+				c.Ports[j].Protocol = corev1.ProtocolTCP
+			}
+		}
+		if c.TerminationMessagePath == "" {
+			c.TerminationMessagePath = "/dev/termination-log"
+		}
+		if c.TerminationMessagePolicy == "" {
+			c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		}
+		for _, probe := range []*corev1.Probe{c.LivenessProbe, c.ReadinessProbe} {
+			if probe == nil {
+				continue
+			}
+			if probe.PeriodSeconds == 0 {
+				probe.PeriodSeconds = 10
+			}
+			if probe.SuccessThreshold == 0 {
+				probe.SuccessThreshold = 1
+			}
+			if probe.FailureThreshold == 0 {
+				probe.FailureThreshold = 3
+			}
+			if probe.HTTPGet != nil && probe.HTTPGet.Scheme == "" {
+				probe.HTTPGet.Scheme = corev1.URISchemeHTTP
+			}
+		}
+	}
+}

--- a/controllers/pushgateway/manifest.go
+++ b/controllers/pushgateway/manifest.go
@@ -46,7 +46,6 @@ func pushgatewayDeployment(cr *monv1.PlatformMonitoring) (*appsv1.Deployment, er
 				for p := range c.Ports {
 					port := &c.Ports[p]
 					if port.Name == utils.PushgatewayPortName {
-						port.HostPort = portValue
 						port.ContainerPort = portValue
 					}
 				}

--- a/controllers/utils/skip_update.go
+++ b/controllers/utils/skip_update.go
@@ -32,21 +32,6 @@ func SetLabelsIfChanged(obj metav1.Object, labels map[string]string) bool {
 	return true
 }
 
-// SetManagedAnnotationsIfChanged copies keys from annotations onto obj without
-// removing keys obj already has (for example Deployment revision). Empty
-// annotations are a no-op. Returns true when annotations were updated.
-func SetManagedAnnotationsIfChanged(obj metav1.Object, annotations map[string]string) bool {
-	if len(annotations) == 0 {
-		return false
-	}
-	merged := maps.Clone(obj.GetAnnotations())
-	if merged == nil {
-		merged = make(map[string]string, len(annotations))
-	}
-	maps.Copy(merged, annotations)
-	return SetAnnotationsIfChanged(obj, merged)
-}
-
 // SetAnnotationsIfChanged assigns annotations when they differ. Nil and empty
 // maps are treated as equal. Callers that must distinguish omitted versus empty
 // should canonicalize before calling. Returns true when annotations were updated.

--- a/controllers/utils/skip_update.go
+++ b/controllers/utils/skip_update.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"encoding/json"
+	"maps"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+)
+
+// SetIfChanged assigns src to *dst when they are not equal. Equality uses
+// Kubernetes Semantic.DeepEqual, which understands API types (Quantity, Time)
+// and treats nil maps/slices as equal to empty ones. Returns true when *dst
+// was updated.
+func SetIfChanged[T any](dst *T, src T) bool {
+	if apiequality.Semantic.DeepEqual(*dst, src) {
+		return false
+	}
+	*dst = src
+	return true
+}
+
+// SetLabelsIfChanged assigns labels when they differ according to
+// labels.Equals (nil and empty maps are equal). Returns true when labels
+// were updated.
+func SetLabelsIfChanged(obj metav1.Object, labels map[string]string) bool {
+	if k8slabels.Equals(obj.GetLabels(), labels) {
+		return false
+	}
+	obj.SetLabels(labels)
+	return true
+}
+
+// SetAnnotationsIfChanged assigns annotations when they differ. Nil and empty
+// maps are treated as equal. Callers that must distinguish omitted versus empty
+// should canonicalize before calling. Returns true when annotations were updated.
+func SetAnnotationsIfChanged(obj metav1.Object, annotations map[string]string) bool {
+	if maps.Equal(obj.GetAnnotations(), annotations) {
+		return false
+	}
+	obj.SetAnnotations(annotations)
+	return true
+}
+
+// SetUnstructuredFieldIfChanged assigns obj[key] when the values differ.
+// Comparison uses Semantic equality, then a JSON round-trip so numbers that the
+// apiserver decoded as float64 still match in-memory int/int32 builders.
+// Returns true when the field was updated.
+func SetUnstructuredFieldIfChanged(obj map[string]interface{}, key string, src interface{}) bool {
+	if unstructuredValuesEqual(obj[key], src) {
+		return false
+	}
+	obj[key] = src
+	return true
+}
+
+func unstructuredValuesEqual(a, b interface{}) bool {
+	if apiequality.Semantic.DeepEqual(a, b) {
+		return true
+	}
+	ab, err := json.Marshal(a)
+	if err != nil {
+		return false
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		return false
+	}
+	var ao, bo interface{}
+	if err := json.Unmarshal(ab, &ao); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(bb, &bo); err != nil {
+		return false
+	}
+	return apiequality.Semantic.DeepEqual(ao, bo)
+}

--- a/controllers/utils/skip_update.go
+++ b/controllers/utils/skip_update.go
@@ -32,6 +32,21 @@ func SetLabelsIfChanged(obj metav1.Object, labels map[string]string) bool {
 	return true
 }
 
+// SetManagedAnnotationsIfChanged copies keys from annotations onto obj without
+// removing keys obj already has (for example Deployment revision). Empty
+// annotations are a no-op. Returns true when annotations were updated.
+func SetManagedAnnotationsIfChanged(obj metav1.Object, annotations map[string]string) bool {
+	if len(annotations) == 0 {
+		return false
+	}
+	merged := maps.Clone(obj.GetAnnotations())
+	if merged == nil {
+		merged = make(map[string]string, len(annotations))
+	}
+	maps.Copy(merged, annotations)
+	return SetAnnotationsIfChanged(obj, merged)
+}
+
 // SetAnnotationsIfChanged assigns annotations when they differ. Nil and empty
 // maps are treated as equal. Callers that must distinguish omitted versus empty
 // should canonicalize before calling. Returns true when annotations were updated.

--- a/controllers/utils/skip_update_test.go
+++ b/controllers/utils/skip_update_test.go
@@ -1,0 +1,119 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetIfChangedNoOp(t *testing.T) {
+	rules := []rbacv1.PolicyRule{{
+		APIGroups: []string{""},
+		Resources: []string{"pods"},
+		Verbs:     []string{"get"},
+	}}
+	dst := append([]rbacv1.PolicyRule(nil), rules...)
+
+	assert.False(t, SetIfChanged(&dst, rules))
+	assert.Equal(t, rules, dst)
+}
+
+func TestSetIfChangedSpecOnly(t *testing.T) {
+	dst := corev1.ServiceSpec{
+		Ports: []corev1.ServicePort{{Name: "http", Port: 80}},
+	}
+	src := corev1.ServiceSpec{
+		Ports: []corev1.ServicePort{{Name: "http", Port: 443}},
+	}
+
+	assert.True(t, SetIfChanged(&dst, src))
+	assert.Equal(t, int32(443), dst.Ports[0].Port)
+}
+
+func TestSetIfChangedTreatsNilAndEmptySliceAsEqual(t *testing.T) {
+	var dst []string
+	src := []string{}
+
+	assert.False(t, SetIfChanged(&dst, src), "k8s Semantic.DeepEqual treats nil and empty slices as equal")
+	assert.Nil(t, dst)
+}
+
+func TestSetIfChangedTreatsNilAndEmptyMapAsEqual(t *testing.T) {
+	var dst map[string]string
+	src := map[string]string{}
+
+	assert.False(t, SetIfChanged(&dst, src), "k8s Semantic.DeepEqual treats nil and empty maps as equal")
+	assert.Nil(t, dst)
+}
+
+func TestSetLabelsIfChangedNoOp(t *testing.T) {
+	obj := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "x"}},
+	}
+
+	assert.False(t, SetLabelsIfChanged(obj, map[string]string{"app": "x"}))
+	assert.Equal(t, map[string]string{"app": "x"}, obj.GetLabels())
+}
+
+func TestSetLabelsIfChangedNilEqualsEmpty(t *testing.T) {
+	obj := &corev1.Service{}
+
+	assert.False(t, SetLabelsIfChanged(obj, map[string]string{}), "labels.Equals treats nil and empty maps as equal")
+	assert.Nil(t, obj.GetLabels())
+}
+
+func TestSetLabelsIfChangedUpdates(t *testing.T) {
+	obj := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "old"}},
+	}
+
+	assert.True(t, SetLabelsIfChanged(obj, map[string]string{"app": "new"}))
+	assert.Equal(t, map[string]string{"app": "new"}, obj.GetLabels())
+}
+
+func TestSetAnnotationsIfChangedNilEqualsEmpty(t *testing.T) {
+	obj := &corev1.Service{}
+
+	assert.False(t, SetAnnotationsIfChanged(obj, map[string]string{}))
+	assert.Nil(t, obj.GetAnnotations())
+}
+
+func TestSetAnnotationsIfChangedUpdates(t *testing.T) {
+	obj := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"k": "old"}},
+	}
+
+	assert.True(t, SetAnnotationsIfChanged(obj, map[string]string{"k": "new"}))
+	assert.Equal(t, map[string]string{"k": "new"}, obj.GetAnnotations())
+}
+
+func TestSetUnstructuredFieldIfChangedNoOp(t *testing.T) {
+	obj := map[string]interface{}{
+		"spec": map[string]interface{}{"hostnames": []interface{}{"a.example"}},
+	}
+	src := map[string]interface{}{"hostnames": []interface{}{"a.example"}}
+
+	assert.False(t, SetUnstructuredFieldIfChanged(obj, "spec", src))
+}
+
+func TestSetUnstructuredFieldIfChangedUpdates(t *testing.T) {
+	obj := map[string]interface{}{
+		"spec": map[string]interface{}{"hostnames": []interface{}{"a.example"}},
+	}
+	src := map[string]interface{}{"hostnames": []interface{}{"b.example"}}
+
+	assert.True(t, SetUnstructuredFieldIfChanged(obj, "spec", src))
+	assert.Equal(t, src, obj["spec"])
+}
+
+func TestSetUnstructuredFieldIfChangedJSONNumberCanonical(t *testing.T) {
+	obj := map[string]interface{}{
+		"spec": map[string]interface{}{"port": float64(3000)},
+	}
+	src := map[string]interface{}{"port": int32(3000)}
+
+	assert.False(t, SetUnstructuredFieldIfChanged(obj, "spec", src))
+}

--- a/controllers/utils/skip_update_test.go
+++ b/controllers/utils/skip_update_test.go
@@ -97,26 +97,13 @@ func TestSetAnnotationsIfChangedUpdates(t *testing.T) {
 	assert.Equal(t, map[string]string{"k": "new"}, obj.GetAnnotations())
 }
 
-func TestSetManagedAnnotationsIfChangedEmptyIsNoOp(t *testing.T) {
+func TestSetAnnotationsIfChangedRemovesKeys(t *testing.T) {
 	obj := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"}},
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"keep": "v", "drop": "x"}},
 	}
 
-	assert.False(t, SetManagedAnnotationsIfChanged(obj, nil))
-	assert.False(t, SetManagedAnnotationsIfChanged(obj, map[string]string{}))
-	assert.Equal(t, map[string]string{"deployment.kubernetes.io/revision": "1"}, obj.GetAnnotations())
-}
-
-func TestSetManagedAnnotationsIfChangedMergesWithoutDroppingExisting(t *testing.T) {
-	obj := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"}},
-	}
-
-	assert.True(t, SetManagedAnnotationsIfChanged(obj, map[string]string{"k": "v"}))
-	assert.Equal(t, map[string]string{
-		"deployment.kubernetes.io/revision": "1",
-		"k":                                 "v",
-	}, obj.GetAnnotations())
+	assert.True(t, SetAnnotationsIfChanged(obj, map[string]string{"keep": "v"}))
+	assert.Equal(t, map[string]string{"keep": "v"}, obj.GetAnnotations())
 }
 
 func TestSetUnstructuredFieldIfChangedNoOp(t *testing.T) {

--- a/controllers/utils/skip_update_test.go
+++ b/controllers/utils/skip_update_test.go
@@ -49,6 +49,13 @@ func TestSetIfChangedTreatsNilAndEmptyMapAsEqual(t *testing.T) {
 	assert.Nil(t, dst)
 }
 
+func TestSetIfChangedDoesNotEquateEmptyAndDefaultProtocol(t *testing.T) {
+	dst := []corev1.ServicePort{{Name: "webhook", Port: 443}}
+	src := []corev1.ServicePort{{Name: "webhook", Port: 443, Protocol: corev1.ProtocolTCP}}
+
+	assert.True(t, SetIfChanged(&dst, src), "Semantic.DeepEqual does not treat omitted protocol as TCP")
+}
+
 func TestSetLabelsIfChangedNoOp(t *testing.T) {
 	obj := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "x"}},
@@ -88,6 +95,28 @@ func TestSetAnnotationsIfChangedUpdates(t *testing.T) {
 
 	assert.True(t, SetAnnotationsIfChanged(obj, map[string]string{"k": "new"}))
 	assert.Equal(t, map[string]string{"k": "new"}, obj.GetAnnotations())
+}
+
+func TestSetManagedAnnotationsIfChangedEmptyIsNoOp(t *testing.T) {
+	obj := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"}},
+	}
+
+	assert.False(t, SetManagedAnnotationsIfChanged(obj, nil))
+	assert.False(t, SetManagedAnnotationsIfChanged(obj, map[string]string{}))
+	assert.Equal(t, map[string]string{"deployment.kubernetes.io/revision": "1"}, obj.GetAnnotations())
+}
+
+func TestSetManagedAnnotationsIfChangedMergesWithoutDroppingExisting(t *testing.T) {
+	obj := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"}},
+	}
+
+	assert.True(t, SetManagedAnnotationsIfChanged(obj, map[string]string{"k": "v"}))
+	assert.Equal(t, map[string]string{
+		"deployment.kubernetes.io/revision": "1",
+		"k":                                 "v",
+	}, obj.GetAnnotations())
 }
 
 func TestSetUnstructuredFieldIfChangedNoOp(t *testing.T) {

--- a/controllers/victoriametrics/vmagent/handlers.go
+++ b/controllers/victoriametrics/vmagent/handlers.go
@@ -30,7 +30,10 @@ func (r *VmAgentReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring) e
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -56,9 +59,11 @@ func (r *VmAgentReconciler) handleClusterRole(cr *monv1.PlatformMonitoring) erro
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -85,7 +90,10 @@ func (r *VmAgentReconciler) handleClusterRoleBinding(cr *monv1.PlatformMonitorin
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -112,9 +120,11 @@ func (r *VmAgentReconciler) handleRole(cr *monv1.PlatformMonitoring) error {
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -141,7 +151,10 @@ func (r *VmAgentReconciler) handleRoleBinding(cr *monv1.PlatformMonitoring) erro
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -176,8 +189,11 @@ func (r *VmAgentReconciler) handleVmAgent(cr *monv1.PlatformMonitoring) error {
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -212,10 +228,13 @@ func (r *VmAgentReconciler) handleIngressV1(cr *monv1.PlatformMonitoring) error 
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/victoriametrics/vmalert/handlers.go
+++ b/controllers/victoriametrics/vmalert/handlers.go
@@ -30,7 +30,10 @@ func (r *VmAlertReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring) e
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -56,9 +59,11 @@ func (r *VmAlertReconciler) handleClusterRole(cr *monv1.PlatformMonitoring) erro
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -85,7 +90,10 @@ func (r *VmAlertReconciler) handleClusterRoleBinding(cr *monv1.PlatformMonitorin
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -120,8 +128,11 @@ func (r *VmAlertReconciler) handleVmAlert(cr *monv1.PlatformMonitoring) error {
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -156,10 +167,13 @@ func (r *VmAlertReconciler) handleIngressV1(cr *monv1.PlatformMonitoring) error 
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/victoriametrics/vmalertmanager/handlers.go
+++ b/controllers/victoriametrics/vmalertmanager/handlers.go
@@ -30,7 +30,10 @@ func (r *VmAlertManagerReconciler) handleServiceAccount(cr *monv1.PlatformMonito
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -57,9 +60,11 @@ func (r *VmAlertManagerReconciler) handleClusterRole(cr *monv1.PlatformMonitorin
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -86,7 +91,10 @@ func (r *VmAlertManagerReconciler) handleClusterRoleBinding(cr *monv1.PlatformMo
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -113,9 +121,11 @@ func (r *VmAlertManagerReconciler) handleRole(cr *monv1.PlatformMonitoring) erro
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -142,7 +152,10 @@ func (r *VmAlertManagerReconciler) handleRoleBinding(cr *monv1.PlatformMonitorin
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -177,8 +190,11 @@ func (r *VmAlertManagerReconciler) handleVmAlertManager(cr *monv1.PlatformMonito
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -214,7 +230,10 @@ func (r *VmAlertManagerReconciler) handleSecret(cr *monv1.PlatformMonitoring) er
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -249,10 +268,13 @@ func (r *VmAlertManagerReconciler) handleIngressV1(cr *monv1.PlatformMonitoring)
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/victoriametrics/vmauth/handlers.go
+++ b/controllers/victoriametrics/vmauth/handlers.go
@@ -2,6 +2,7 @@ package vmauth
 
 import (
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	vmetricsv1b1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -28,7 +29,10 @@ func (r *VmAuthReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring) er
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -55,9 +59,11 @@ func (r *VmAuthReconciler) handleClusterRole(cr *monv1.PlatformMonitoring) error
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -84,7 +90,10 @@ func (r *VmAuthReconciler) handleClusterRoleBinding(cr *monv1.PlatformMonitoring
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -111,9 +120,11 @@ func (r *VmAuthReconciler) handleRole(cr *monv1.PlatformMonitoring) error {
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -140,7 +151,10 @@ func (r *VmAuthReconciler) handleRoleBinding(cr *monv1.PlatformMonitoring) error
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -166,8 +180,11 @@ func (r *VmAuthReconciler) handleVmAuth(cr *monv1.PlatformMonitoring) error {
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -193,10 +210,13 @@ func (r *VmAuthReconciler) handleIngress(cr *monv1.PlatformMonitoring) error {
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/victoriametrics/vmcluster/handlers.go
+++ b/controllers/victoriametrics/vmcluster/handlers.go
@@ -30,7 +30,10 @@ func (r *VmClusterReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring)
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -56,9 +59,11 @@ func (r *VmClusterReconciler) handleClusterRole(cr *monv1.PlatformMonitoring) er
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -85,7 +90,10 @@ func (r *VmClusterReconciler) handleClusterRoleBinding(cr *monv1.PlatformMonitor
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -120,10 +128,13 @@ func (r *VmClusterReconciler) handleIngressV1(cr *monv1.PlatformMonitoring) erro
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -158,8 +169,11 @@ func (r *VmClusterReconciler) handleVmCluster(cr *monv1.PlatformMonitoring) erro
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/victoriametrics/vmoperator/assets/kube-controller-manager-endpoints.yaml
+++ b/controllers/victoriametrics/vmoperator/assets/kube-controller-manager-endpoints.yaml
@@ -12,3 +12,4 @@ subsets:
   - ports:
       - name: "https-metrics"
         port: 10257
+        protocol: TCP

--- a/controllers/victoriametrics/vmoperator/assets/kube-scheduler-endpoints.yaml
+++ b/controllers/victoriametrics/vmoperator/assets/kube-scheduler-endpoints.yaml
@@ -12,3 +12,4 @@ subsets:
   - ports:
       - name: "https-metrics"
         port: 10259
+        protocol: TCP

--- a/controllers/victoriametrics/vmoperator/assets/kubelet-endpoints.yaml
+++ b/controllers/victoriametrics/vmoperator/assets/kubelet-endpoints.yaml
@@ -12,7 +12,10 @@ subsets:
   - ports:
       - name: "https-metrics"
         port: 10250
+        protocol: TCP
       - name: "http-metrics"
         port: 10255
+        protocol: TCP
       - name: "cadvisor"
         port: 4194
+        protocol: TCP

--- a/controllers/victoriametrics/vmoperator/assets/service.yaml
+++ b/controllers/victoriametrics/vmoperator/assets/service.yaml
@@ -17,5 +17,6 @@ spec:
     - name: webhook
       port: 443
       targetPort: 9443
+      protocol: TCP
   selector:
     app.kubernetes.io/name: victoriametrics-operator

--- a/controllers/victoriametrics/vmoperator/handlers.go
+++ b/controllers/victoriametrics/vmoperator/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
@@ -39,9 +40,11 @@ func (r *VmOperatorReconciler) handleRole(cr *monv1.PlatformMonitoring) error {
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -68,7 +71,10 @@ func (r *VmOperatorReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -95,7 +101,10 @@ func (r *VmOperatorReconciler) handleRoleBinding(cr *monv1.PlatformMonitoring) e
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -122,9 +131,11 @@ func (r *VmOperatorReconciler) handleClusterRole(cr *monv1.PlatformMonitoring) e
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -151,7 +162,10 @@ func (r *VmOperatorReconciler) handleClusterRoleBinding(cr *monv1.PlatformMonito
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -183,16 +197,19 @@ func (r *VmOperatorReconciler) handleDeployment(cr *monv1.PlatformMonitoring) er
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Selector = m.Spec.Selector
-	e.Spec.Template.SetLabels(m.Spec.Template.GetLabels())
-	e.Spec.Template.Spec.SecurityContext = m.Spec.Template.Spec.SecurityContext
-	e.Spec.Template.Spec.Affinity = m.Spec.Template.Spec.Affinity
-	e.Spec.Template.Spec.Volumes = m.Spec.Template.Spec.Volumes
-	e.Spec.Template.Spec.Containers = m.Spec.Template.Spec.Containers
-	e.Spec.Template.Spec.ServiceAccountName = m.Spec.Template.Spec.ServiceAccountName
-	e.Spec.Template.Spec.PriorityClassName = m.Spec.Template.Spec.PriorityClassName
-	e.Spec.Replicas = m.Spec.Replicas
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	changed = utils.SetLabelsIfChanged(&e.Spec.Template, m.Spec.Template.GetLabels()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.SecurityContext, m.Spec.Template.Spec.SecurityContext) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Affinity, m.Spec.Template.Spec.Affinity) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Volumes, m.Spec.Template.Spec.Volumes) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.Containers, m.Spec.Template.Spec.Containers) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.ServiceAccountName, m.Spec.Template.Spec.ServiceAccountName) || changed
+	changed = utils.SetIfChanged(&e.Spec.Template.Spec.PriorityClassName, m.Spec.Template.Spec.PriorityClassName) || changed
+	changed = utils.SetIfChanged(&e.Spec.Replicas, m.Spec.Replicas) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -219,9 +236,12 @@ func (r *VmOperatorReconciler) handleService(cr *monv1.PlatformMonitoring) error
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -248,9 +268,12 @@ func (r *VmOperatorReconciler) handleKubeletService(cr *monv1.PlatformMonitoring
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -298,8 +321,11 @@ func (r *VmOperatorReconciler) handleKubeletServiceEndpoints(cr *monv1.PlatformM
 	}
 
 	//Set parameters
-	e.SetLabels(eps.GetLabels())
-	e.Subsets = eps.Subsets
+	changed := utils.SetLabelsIfChanged(e, eps.GetLabels())
+	changed = utils.SetIfChanged(&e.Subsets, eps.Subsets) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -332,9 +358,12 @@ func (r *VmOperatorReconciler) handleKubeSchedulerService(cr *monv1.PlatformMoni
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -383,8 +412,11 @@ func (r *VmOperatorReconciler) handleKubeSchedulerServiceEndpoints(cr *monv1.Pla
 	}
 
 	//Set parameters
-	e.SetLabels(eps.GetLabels())
-	e.Subsets = eps.Subsets
+	changed := utils.SetLabelsIfChanged(e, eps.GetLabels())
+	changed = utils.SetIfChanged(&e.Subsets, eps.Subsets) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -416,9 +448,12 @@ func (r *VmOperatorReconciler) handleKubeControllerManagerService(cr *monv1.Plat
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.Ports = m.Spec.Ports
-	e.Spec.Selector = m.Spec.Selector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.Ports, m.Spec.Ports) || changed
+	changed = utils.SetIfChanged(&e.Spec.Selector, m.Spec.Selector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -467,8 +502,11 @@ func (r *VmOperatorReconciler) handleKubeControllerManagerServiceEndpoints(cr *m
 	}
 
 	//Set parameters
-	e.SetLabels(eps.GetLabels())
-	e.Subsets = eps.Subsets
+	changed := utils.SetLabelsIfChanged(e, eps.GetLabels())
+	changed = utils.SetIfChanged(&e.Subsets, eps.Subsets) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -537,6 +575,20 @@ func getNodeAddresses(nodes *corev1.NodeList) ([]corev1.EndpointAddress, []error
 		})
 	}
 
+	sort.Slice(addresses, func(i, j int) bool {
+		if addresses[i].IP != addresses[j].IP {
+			return addresses[i].IP < addresses[j].IP
+		}
+		ni, nj := "", ""
+		if addresses[i].TargetRef != nil {
+			ni = addresses[i].TargetRef.Name
+		}
+		if addresses[j].TargetRef != nil {
+			nj = addresses[j].TargetRef.Name
+		}
+		return ni < nj
+	})
+
 	return addresses, ers
 }
 
@@ -561,10 +613,13 @@ func (r *VmOperatorReconciler) handleServiceMonitor(cr *monv1.PlatformMonitoring
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec.JobLabel = m.Spec.JobLabel
-	e.Spec.Endpoints = m.Spec.Endpoints
-	e.Spec.NamespaceSelector = m.Spec.NamespaceSelector
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec.JobLabel, m.Spec.JobLabel) || changed
+	changed = utils.SetIfChanged(&e.Spec.Endpoints, m.Spec.Endpoints) || changed
+	changed = utils.SetIfChanged(&e.Spec.NamespaceSelector, m.Spec.NamespaceSelector) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -592,7 +647,10 @@ func (r *VmOperatorReconciler) handleSecurityContextConstraints(cr *monv1.Platfo
 		return err
 	}
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/victoriametrics/vmoperator/handlers_skip_test.go
+++ b/controllers/victoriametrics/vmoperator/handlers_skip_test.go
@@ -71,6 +71,66 @@ func TestHandleKubeletServiceEndpointsSkipsAPIDefaultedPortProtocol(t *testing.T
 	assert.Equal(t, corev1.ProtocolTCP, got.Subsets[0].Ports[0].Protocol)
 }
 
+func TestHandleServiceUpdatesChangedPort(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := vmOperatorService(cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	require.NotEmpty(t, live.Spec.Ports)
+	live.Spec.Ports[0].Port = 9999
+
+	r := newVmOperatorSkipTestReconciler(t, nil, cr, live)
+	require.NoError(t, r.handleService(cr))
+
+	got := &corev1.Service{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "port change must trigger Update")
+	require.NotEmpty(t, got.Spec.Ports)
+	assert.Equal(t, desired.Spec.Ports[0].Port, got.Spec.Ports[0].Port)
+}
+
+func TestHandleKubeletServiceEndpointsUpdatesChangedPort(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "kind-control-plane", UID: "node-uid"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "172.18.0.2"}},
+		},
+	}
+	kubeClient := kubernetesfake.NewSimpleClientset(node)
+
+	nodes, err := kubeClient.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	addresses, addressErrs := getNodeAddresses(nodes)
+	require.Empty(t, addressErrs)
+
+	desired, err := vmKubeletServiceEndpoints(cr)
+	require.NoError(t, err)
+	desired.Subsets[0].Addresses = addresses
+	desired.Labels["name"] = utils.TruncLabel(desired.GetName())
+	desired.Labels["app.kubernetes.io/name"] = utils.TruncLabel(desired.GetName())
+	desired.Labels["app.kubernetes.io/instance"] = utils.GetInstanceLabel(desired.GetName(), desired.GetNamespace())
+	desired.Labels["app.kubernetes.io/version"] = utils.GetTagFromImage(cr.Spec.Victoriametrics.VmOperator.Image)
+	applyAPIDefaultedEndpointPorts(desired.Subsets)
+
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	require.NotEmpty(t, live.Subsets)
+	require.NotEmpty(t, live.Subsets[0].Ports)
+	live.Subsets[0].Ports[0].Port = 1
+
+	r := newVmOperatorSkipTestReconciler(t, kubeClient, cr, live)
+	require.NoError(t, r.handleKubeletServiceEndpoints(cr))
+
+	got := &corev1.Endpoints{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "port change must trigger Update")
+	require.NotEmpty(t, got.Subsets)
+	require.NotEmpty(t, got.Subsets[0].Ports)
+	assert.Equal(t, int32(10250), got.Subsets[0].Ports[0].Port)
+}
+
 func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
 	install := true
 	return &monv1.PlatformMonitoring{

--- a/controllers/victoriametrics/vmoperator/handlers_skip_test.go
+++ b/controllers/victoriametrics/vmoperator/handlers_skip_test.go
@@ -1,0 +1,133 @@
+package vmoperator
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandleServiceSkipsAPIDefaultedPortProtocol(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	desired, err := vmOperatorService(cr)
+	require.NoError(t, err)
+
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	applyAPIDefaultedServicePorts(live.Spec.Ports)
+
+	r := newVmOperatorSkipTestReconciler(t, nil, cr, live)
+	require.NoError(t, r.handleService(cr))
+
+	got := &corev1.Service{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted Service port protocol must not trigger Update")
+	assert.Equal(t, corev1.ProtocolTCP, portProtocol(got.Spec.Ports, "webhook"))
+}
+
+func TestHandleKubeletServiceEndpointsSkipsAPIDefaultedPortProtocol(t *testing.T) {
+	cr := skipTestPlatformMonitoring()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "kind-control-plane", UID: "node-uid"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "172.18.0.2"}},
+		},
+	}
+	kubeClient := kubernetesfake.NewSimpleClientset(node)
+
+	nodes, err := kubeClient.CoreV1().Nodes().List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	addresses, addressErrs := getNodeAddresses(nodes)
+	require.Empty(t, addressErrs)
+
+	desired, err := vmKubeletServiceEndpoints(cr)
+	require.NoError(t, err)
+	desired.Subsets[0].Addresses = addresses
+	desired.Labels["name"] = utils.TruncLabel(desired.GetName())
+	desired.Labels["app.kubernetes.io/name"] = utils.TruncLabel(desired.GetName())
+	desired.Labels["app.kubernetes.io/instance"] = utils.GetInstanceLabel(desired.GetName(), desired.GetNamespace())
+	desired.Labels["app.kubernetes.io/version"] = utils.GetTagFromImage(cr.Spec.Victoriametrics.VmOperator.Image)
+	applyAPIDefaultedEndpointPorts(desired.Subsets)
+	desired.ResourceVersion = "1"
+
+	r := newVmOperatorSkipTestReconciler(t, kubeClient, cr, desired.DeepCopy())
+	require.NoError(t, r.handleKubeletServiceEndpoints(cr))
+
+	got := &corev1.Endpoints{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "API-defaulted Endpoints port protocol must not trigger Update")
+	require.NotEmpty(t, got.Subsets)
+	require.NotEmpty(t, got.Subsets[0].Ports)
+	assert.Equal(t, corev1.ProtocolTCP, got.Subsets[0].Ports[0].Protocol)
+}
+
+func skipTestPlatformMonitoring() *monv1.PlatformMonitoring {
+	install := true
+	return &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Victoriametrics: &monv1.Victoriametrics{
+				VmOperator: monv1.VmOperator{
+					Install: &install,
+					Image:   "victoriametrics/operator:v0.73.1",
+				},
+			},
+		},
+	}
+}
+
+func newVmOperatorSkipTestReconciler(t *testing.T, kubeClient kubernetes.Interface, objs ...client.Object) *VmOperatorReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return &VmOperatorReconciler{
+		KubeClient: kubeClient,
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+			Scheme: scheme,
+			Log:    utils.Logger("vmoperator_skip_test"),
+		},
+	}
+}
+
+func applyAPIDefaultedServicePorts(ports []corev1.ServicePort) {
+	for i := range ports {
+		if ports[i].Protocol == "" {
+			ports[i].Protocol = corev1.ProtocolTCP
+		}
+	}
+}
+
+func applyAPIDefaultedEndpointPorts(subsets []corev1.EndpointSubset) {
+	for i := range subsets {
+		for j := range subsets[i].Ports {
+			if subsets[i].Ports[j].Protocol == "" {
+				subsets[i].Ports[j].Protocol = corev1.ProtocolTCP
+			}
+		}
+	}
+}
+
+func portProtocol(ports []corev1.ServicePort, name string) corev1.Protocol {
+	for _, p := range ports {
+		if p.Name == name {
+			return p.Protocol
+		}
+	}
+	return ""
+}

--- a/controllers/victoriametrics/vmsingle/handlers.go
+++ b/controllers/victoriametrics/vmsingle/handlers.go
@@ -30,7 +30,10 @@ func (r *VmSingleReconciler) handleServiceAccount(cr *monv1.PlatformMonitoring) 
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -56,9 +59,11 @@ func (r *VmSingleReconciler) handleClusterRole(cr *monv1.PlatformMonitoring) err
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetName(m.GetName())
-	e.Rules = m.Rules
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Rules, m.Rules) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -85,7 +90,10 @@ func (r *VmSingleReconciler) handleClusterRoleBinding(cr *monv1.PlatformMonitori
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -120,8 +128,11 @@ func (r *VmSingleReconciler) handleVmSingle(cr *monv1.PlatformMonitoring) error 
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err
@@ -156,10 +167,13 @@ func (r *VmSingleReconciler) handleIngressV1(cr *monv1.PlatformMonitoring) error
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.SetAnnotations(m.GetAnnotations())
-	e.Spec.Rules = m.Spec.Rules
-	e.Spec.TLS = m.Spec.TLS
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetAnnotationsIfChanged(e, m.GetAnnotations()) || changed
+	changed = utils.SetIfChanged(&e.Spec.Rules, m.Spec.Rules) || changed
+	changed = utils.SetIfChanged(&e.Spec.TLS, m.Spec.TLS) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err

--- a/controllers/victoriametrics/vmsingle/handlers_skip_test.go
+++ b/controllers/victoriametrics/vmsingle/handlers_skip_test.go
@@ -41,6 +41,35 @@ func TestHandleVmSingleSkipsNoOpUpdate(t *testing.T) {
 	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
 }
 
+func TestHandleVmSingleUpdatesChangedSpec(t *testing.T) {
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Victoriametrics: &monv1.Victoriametrics{
+				VmSingle: monv1.VmSingle{Image: "vmsingle:current"},
+			},
+		},
+	}
+	r := newVmSingleSkipTestReconciler(t, cr)
+	desired, err := vmSingle(r, cr)
+	require.NoError(t, err)
+	live := desired.DeepCopy()
+	live.ResourceVersion = "1"
+	live.Spec.Image.Tag = "stale"
+
+	r = newVmSingleSkipTestReconciler(t, cr, live)
+	require.NoError(t, r.handleVmSingle(cr))
+
+	got := &vmetricsv1b1.VMSingle{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.NotEqual(t, "1", got.ResourceVersion, "spec change must trigger Update")
+	assert.Equal(t, desired.Spec.Image, got.Spec.Image)
+}
+
 func newVmSingleSkipTestReconciler(t *testing.T, objs ...client.Object) *VmSingleReconciler {
 	t.Helper()
 	scheme := runtime.NewScheme()

--- a/controllers/victoriametrics/vmsingle/handlers_skip_test.go
+++ b/controllers/victoriametrics/vmsingle/handlers_skip_test.go
@@ -1,0 +1,56 @@
+package vmsingle
+
+import (
+	"testing"
+
+	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
+	vmetricsv1b1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHandleVmSingleSkipsNoOpUpdate(t *testing.T) {
+	cr := &monv1.PlatformMonitoring{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "platformmonitoring",
+			Namespace: "monitoring",
+			UID:       types.UID("platform-monitoring-uid"),
+		},
+		Spec: monv1.PlatformMonitoringSpec{
+			Victoriametrics: &monv1.Victoriametrics{
+				VmSingle: monv1.VmSingle{Image: "vmsingle:current"},
+			},
+		},
+	}
+	r := newVmSingleSkipTestReconciler(t, cr)
+	desired, err := vmSingle(r, cr)
+	require.NoError(t, err)
+	desired.ResourceVersion = "1"
+
+	r = newVmSingleSkipTestReconciler(t, cr, desired.DeepCopy())
+	require.NoError(t, r.handleVmSingle(cr))
+
+	got := &vmetricsv1b1.VMSingle{}
+	require.NoError(t, r.Client.Get(t.Context(), client.ObjectKeyFromObject(desired), got))
+	assert.Equal(t, "1", got.ResourceVersion, "no-op reconcile must not bump resourceVersion")
+}
+
+func newVmSingleSkipTestReconciler(t *testing.T, objs ...client.Object) *VmSingleReconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, vmetricsv1b1.AddToScheme(scheme))
+	return &VmSingleReconciler{
+		ComponentReconciler: &utils.ComponentReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+			Scheme: scheme,
+			Log:    utils.Logger("vmsingle_skip_test"),
+		},
+	}
+}

--- a/controllers/victoriametrics/vmuser/handlers.go
+++ b/controllers/victoriametrics/vmuser/handlers.go
@@ -2,6 +2,7 @@ package vmuser
 
 import (
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
+	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	vmetricsv1b1 "github.com/VictoriaMetrics/operator/api/operator/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -24,8 +25,11 @@ func (r *VmUserReconciler) handleVmUser(cr *monv1.PlatformMonitoring) error {
 	}
 
 	//Set parameters
-	e.SetLabels(m.GetLabels())
-	e.Spec = m.Spec
+	changed := utils.SetLabelsIfChanged(e, m.GetLabels())
+	changed = utils.SetIfChanged(&e.Spec, m.Spec) || changed
+	if !changed {
+		return nil
+	}
 
 	if err = r.UpdateResource(e); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- Close idle PlatformMonitoring rewrite load from [#473](https://github.com/Netcracker/qubership-monitoring-operator/issues/473): handlers now `Update` only when the labels/spec fields this controller manages actually changed (`Semantic.DeepEqual` / `labels.Equals`).
- Align desired manifests with known kube/CRD defaults (ports, probes, termination-message, hostPath type, Prometheus/Alertmanager fields) so omit-vs-default does not look like drift.
- Restore pushgateway annotation full-replace (including key removal) while preserving `deployment.kubernetes.io/revision`, and add skip plus positive-update handler tests on the main paths.

## Test plan
- [x] Unit tests for skip helpers and handler skip/update paths (`go test` on affected controller packages)
- [x] Local Kind idle check: default-on stack stopped rewriting RBAC/monitors/VM CRs/Deployments every 60s after skip-if-equal + defaulting
- [ ] CI on this PR
- [ ] Reviewer idle glance on a real cluster if useful (Prometheus+VM both on remains an unsupported dual install; kubelet Service/Endpoints fight is out of scope)

Closes #473

Made with [Cursor](https://cursor.com)