### PR TITLE
fix: allow disabling Grafana

### DIFF
--- a/charts/qubership-monitoring-operator/Chart.yaml
+++ b/charts/qubership-monitoring-operator/Chart.yaml
@@ -19,10 +19,7 @@ appVersion: 0.88.0
 dependencies:
   # Grafana
   - name: grafana
-    # Enable the subchart when either the Grafana instance or only the Grafana Operator is enabled.
-    # This preserves backward compatibility and adds a new "operator-only" scenario
-    # controlled via grafana.operator.install.
-    condition: grafana.install, grafana.operator.install
+    condition: grafana.install
     version: ~0
     repository: "file://charts/grafana"
 

--- a/charts/qubership-monitoring-operator/templates/operator/grafana-cleanup-job.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/grafana-cleanup-job.yaml
@@ -1,6 +1,6 @@
 {{- $values := .Values | toJson | fromJson -}}
 {{- $cleanupHook := dig "victoriametrics" "cleanup" "hook" (dict) $values -}}
-{{- if or .Values.grafana.install .Values.grafana.operator.install .Values.commonDashboards.install }}
+{{- if or .Values.grafana.install .Values.commonDashboards.install }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/qubership-monitoring-operator/templates/operator/grafana-cleanup-rbac.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/grafana-cleanup-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.grafana.install .Values.grafana.operator.install .Values.commonDashboards.install }}
+{{- if or .Values.grafana.install .Values.commonDashboards.install }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/qubership-monitoring-operator/templates/operator/platformmonitoring.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/platformmonitoring.yaml
@@ -1190,7 +1190,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if .Values.grafana }}
-  {{- if or .Values.grafana.install .Values.grafana.operator.install }}
+  {{- if .Values.grafana.install }}
   grafana:
     install: {{ .Values.grafana.install }}
     {{- if hasKey .Values.grafana "disableDefaultAdminSecret" }}

--- a/tools/verify-helm-crds.sh
+++ b/tools/verify-helm-crds.sh
@@ -715,9 +715,11 @@ verify_text_excludes "${grafana_cleanup_command}" \
 
 helm template monitoring "${chart_dir}" \
     --set grafana.install=false \
-    --set grafana.operator.install=false \
     --set commonDashboards.install=true \
     >"${rendered_manifest}"
+verify_rendered_resource_count "${rendered_manifest}" \
+    '.kind == "PlatformMonitoring" and (.spec | has("grafana"))' \
+    0 "PlatformMonitoring Grafana specs in common-dashboard-only mode"
 "${yq_binary}" eval-all \
     'select(.kind == "Job" and .metadata.name == "monitoring-grafana-cleanup-hook") |
     .spec.template.spec.containers[] | select(.name == "kubectl") | .command[-1]' \


### PR DESCRIPTION
## Why

The documented installation flow applies the complete CRD bundle before installing the operator chart. With that prerequisite in place, setting `grafana.install=false` still fails during Helm rendering because the templates read the undefined `grafana.operator.install` value.

## What

- Use `grafana.install` as the only condition for the Grafana subchart and `PlatformMonitoring` Grafana spec.
- Keep common dashboards and their cleanup hook independent for installations that use an externally managed Grafana Operator.
- Cover the common-dashboard-only configuration and verify that it does not emit `spec.grafana`.

## How to verify

- `make test`
- `bash tools/verify-helm-crds.sh`
- `helm lint charts/qubership-monitoring-operator`

Fixes #131
