### PR TITLE
fix(prometheus): preserve persistent storage

### DIFF
--- a/controllers/prometheus/prometheus_test.go
+++ b/controllers/prometheus/prometheus_test.go
@@ -1,13 +1,23 @@
 package prometheus
 
 import (
+	"context"
 	"testing"
 
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils/labelsassert"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	ktesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (
@@ -115,4 +125,84 @@ func TestPrometheusManifests(t *testing.T) {
 		assert.NotNil(t, m, "PodMonitor manifest should not be empty")
 		labelsassert.AssertCRLabels(t, m.GetLabels(), utils.PrometheusComponentName, "prometheus-operator", map[string]string{labelKey: labelValue})
 	})
+}
+
+func TestPrometheusReconciliationPreservesExistingPVC(t *testing.T) {
+	install := true
+	disabled := false
+	storage := &promv1.StorageSpec{}
+	tests := []struct {
+		name       string
+		prometheus *monv1.Prometheus
+		runs       int
+	}{
+		{name: "missing component configuration", runs: 1},
+		{name: "disabled component", prometheus: &monv1.Prometheus{Install: &disabled}, runs: 1},
+		{
+			name:       "removed storage configuration",
+			prometheus: &monv1.Prometheus{Install: &install, Paused: true},
+			runs:       1,
+		},
+		{
+			name: "paused component",
+			prometheus: &monv1.Prometheus{
+				Install: &install,
+				Paused:  true,
+				Storage: storage,
+			},
+			runs: 1,
+		},
+		{
+			name: "ordinary repeated reconciliation",
+			prometheus: &monv1.Prometheus{
+				Install: &install,
+				Storage: storage,
+			},
+			runs: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler, kubeClient := newPrometheusTestReconciler(t, &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prometheus-k8s-db-prometheus-k8s-0",
+					Namespace: "monitoring",
+				},
+			})
+			platformMonitoring := &monv1.PlatformMonitoring{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "platformmonitoring",
+					Namespace: "monitoring",
+					UID:       types.UID("platformmonitoring"),
+				},
+				Spec: monv1.PlatformMonitoringSpec{Prometheus: tt.prometheus},
+			}
+
+			for range tt.runs {
+				require.NoError(t, reconciler.Run(platformMonitoring))
+			}
+
+			pvc := &corev1.PersistentVolumeClaim{}
+			require.NoError(t, kubeClient.Get(
+				context.Background(),
+				types.NamespacedName{Name: "prometheus-k8s-db-prometheus-k8s-0", Namespace: "monitoring"},
+				pvc,
+			))
+		})
+	}
+}
+
+func newPrometheusTestReconciler(t *testing.T, objects ...client.Object) (*PrometheusReconciler, client.Client) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, monv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, promv1.AddToScheme(scheme))
+
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	discoveryClient := &fakediscovery.FakeDiscovery{Fake: &ktesting.Fake{}}
+
+	return NewPrometheusReconciler(kubeClient, scheme, discoveryClient), kubeClient
 }

--- a/controllers/prometheus/reconciler.go
+++ b/controllers/prometheus/reconciler.go
@@ -1,16 +1,10 @@
 package prometheus
 
 import (
-	"context"
-	"fmt"
-
 	monv1 "github.com/Netcracker/qubership-monitoring-operator/api/v1"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/gateway"
 	"github.com/Netcracker/qubership-monitoring-operator/controllers/utils"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -38,10 +32,6 @@ func NewPrometheusReconciler(c client.Client, s *runtime.Scheme, dc discovery.Di
 // Returns true if need to requeue, false otherwise.
 func (r *PrometheusReconciler) Run(cr *monv1.PlatformMonitoring) error {
 	r.Log.Info("Reconciling component")
-
-	if err := r.removePrometheusPVC(cr); err != nil {
-		return err
-	}
 
 	if cr.Spec.Prometheus != nil && cr.Spec.Prometheus.IsInstall() {
 		if !cr.Spec.Prometheus.Paused {
@@ -125,40 +115,6 @@ func (r *PrometheusReconciler) Run(cr *monv1.PlatformMonitoring) error {
 		r.Log.Info("Uninstalling component if exists")
 		r.uninstall(cr)
 		r.Log.Info("Component reconciled")
-	}
-	return nil
-}
-
-// removePrometheusPVC deletes PVC for Prometheus pod if it isn't needed anymore.
-func (r *PrometheusReconciler) removePrometheusPVC(cr *monv1.PlatformMonitoring) error {
-	if cr.Spec.Prometheus == nil || !cr.Spec.Prometheus.IsInstall() || cr.Spec.Prometheus.Storage == nil {
-		// We can use hardcoded value for now because prometheus-operator < v0.40.0
-		// doesn't allow setting metadata for PVC template.
-		// See https://github.com/prometheus-operator/prometheus-operator/issues/3093
-		// ToDo: Implement deleting PVC by special value when prometheus-operator will be upgraded to v0.40.0+
-		pvcName := "prometheus-k8s-db-prometheus-k8s-0"
-
-		// Find PVC resource
-		pvc := &corev1.PersistentVolumeClaim{}
-		err := r.Client.Get(
-			context.TODO(),
-			types.NamespacedName{Name: pvcName, Namespace: cr.GetNamespace()},
-			pvc,
-		)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-
-			return err
-		}
-		// Delete PVC
-		r.Log.Info(fmt.Sprintf("delete Prometheus PVC with name %q as it is not needed anymore", pvc.GetName()))
-		err = r.Client.Delete(context.TODO(), pvc)
-		if err != nil {
-			r.Log.Error(err, fmt.Sprintf("can not delete PVC %q", pvc.GetName()))
-			return err
-		}
 	}
 	return nil
 }

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -191,6 +191,7 @@ After executing the command, all Monitoring components are removed from the sele
 objects are not removed:
 
 * `monitoring-operator`
+* Persistent Prometheus PVCs
 * Some cluster entities like ClusterRoles, ClusterRoleBindings, Security Context Constraints (SCC), and Pod Security
   Policy (PSP)
 
@@ -209,6 +210,17 @@ helm list -n <namespace>
 ```
 
 The command removes all the Kubernetes/OpenShift components associated with the chart and deletes the release.
+Persistent Prometheus PVCs remain so that uninstalling the release does not implicitly remove stored metrics.
+
+To remove stored Prometheus metrics, first verify that the data was migrated or is no longer required. List the claims
+in the monitoring namespace, identify the exact Prometheus PVC, and delete that claim explicitly:
+
+```bash
+kubectl get pvc -n <namespace>
+kubectl delete pvc <prometheus-pvc-name> -n <namespace>
+```
+
+The underlying PV and storage asset then follow the reclaim policy configured by the storage class or PV administrator.
 
 #### Remove all Created CRDs
 

--- a/docs/user-guides/migrate-from-prometheus-to-victoriametrics.md
+++ b/docs/user-guides/migrate-from-prometheus-to-victoriametrics.md
@@ -106,8 +106,9 @@ Endpoint has optional parameter `skip_head=<bool>` - skip data present in the he
 
 Step 2. Download on local host/another storage in Kubernetes
 
-When snapshot is done you should to save on local host or another storage in Kubernetes. It needs to be done because
-during update from Prometheus to VictoriaMetrics all Prometheus components will be deleted and data will be cleaned.
+When the snapshot is ready, save it to a local host or another storage location in Kubernetes. Disabling managed
+Prometheus removes its workload but retains its persistent volume claim. Keep an independent snapshot until the
+migration is complete because PVC availability still depends on the cluster and its storage system.
 
 For copying snapshots on local host you can use `cp` command in `kubectl` tool:
 
@@ -247,3 +248,17 @@ Step 5. Check data in VictoriaMetrics
       `container_cpu_system_seconds_total` metric.
 
    4. You should see list of metrics.
+
+Step 6. Remove retained Prometheus storage when it is no longer needed
+
+Keep the Prometheus PVC until the VictoriaMetrics deployment is healthy, the required historical metrics are available,
+and rollback to Prometheus is no longer required. Then list the claims, identify the exact Prometheus PVC, and delete it
+explicitly:
+
+```bash
+kubectl get pvc -n <platform-monitoring-namespace>
+kubectl delete pvc <prometheus-pvc-name> -n <platform-monitoring-namespace>
+```
+
+Deleting the PVC is irreversible from the monitoring operator's perspective. The underlying PV and storage asset follow
+their configured reclaim policy.


### PR DESCRIPTION
# What does this PR do?

Preserves managed Prometheus PVCs when Prometheus is disabled, its configuration or storage is removed, or the monitoring release is uninstalled. Stored metrics are deleted only through an explicit manual PVC deletion.

The change removes the legacy fixed-name PVC deletion, adds reconciliation coverage for retention scenarios, and updates uninstall and Prometheus-to-VictoriaMetrics migration documentation.

## Why

The current reconciler deletes `prometheus-k8s-db-prometheus-k8s-0` before checking the component state. A configuration change made during the managed Prometheus deprecation window can therefore remove stored metrics without a separate destructive decision.

Closes #505.

Follow-up findings from the Kind check are tracked separately in #507 and #508.

## Verification

- `make test`
- Controller regression coverage for missing configuration, `install=false`, removed storage, pause, and repeated reconciliation
- Kind lifecycle check: persistent Prometheus became available, ordinary Helm uninstall removed PlatformMonitoring, the Prometheus CR, StatefulSet, and pod, while the same PVC and PV remained Bound
- Independent review completed with no remaining findings

## Checklist

- [x] `make generate` is not required because the public API did not change
- [x] `make test` passes
- [x] User-facing uninstall and migration documentation is updated
