### PR TITLE
fix(helm): render empty Prometheus remoteWrite list

### DIFF
--- a/charts/qubership-monitoring-operator/templates/operator/platformmonitoring.yaml
+++ b/charts/qubership-monitoring-operator/templates/operator/platformmonitoring.yaml
@@ -130,6 +130,7 @@ spec:
       {{- toYaml .Values.prometheus.externalLabels | nindent 6 }}
     externalUrl:
       {{- toYaml .Values.prometheus.externalUrl | nindent 6 }}
+    {{- if .Values.prometheus.remoteWrite }}
     remoteWrite:
       {{- range .Values.prometheus.remoteWrite }}
       {{- if .url }}
@@ -203,6 +204,9 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
+    {{- else }}
+    remoteWrite: []
+    {{- end }}
     remoteRead:
       {{- toYaml .Values.prometheus.remoteRead | nindent 6 }}
     secrets:

--- a/tools/verify-helm-crds.sh
+++ b/tools/verify-helm-crds.sh
@@ -7,6 +7,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 yq_binary="${script_dir}/../bin/yq-4.53.2"
 temporary_dir="$(mktemp -d)"
 rendered_manifest="${temporary_dir}/manifest.yaml"
+prometheus_empty_remote_write_manifest="${temporary_dir}/prometheus-empty-remote-write-manifest.yaml"
+prometheus_remote_write_manifest="${temporary_dir}/prometheus-remote-write-manifest.yaml"
 operator_rbac_manifest="${temporary_dir}/operator-rbac.yaml"
 operator_role_manifest="${temporary_dir}/operator-role.yaml"
 cleanup_role_manifest="${temporary_dir}/cleanup-role.yaml"
@@ -502,6 +504,33 @@ verify_exact_rbac_verbs "${operator_rbac_manifest}" apps deployments/scale "get,
 verify_exact_rbac_verbs "${operator_role_manifest}" apps deployments/scale "get,patch,update"
 
 helm template monitoring "${chart_dir}" >"${rendered_manifest}"
+helm template monitoring "${chart_dir}" \
+    --set prometheus.install=true \
+    >"${prometheus_empty_remote_write_manifest}"
+if ! "${yq_binary}" eval-all -e \
+    'select(.apiVersion == "monitoring.netcracker.com/v1" and .kind == "PlatformMonitoring") |
+    (.spec.prometheus.remoteWrite | tag) == "!!seq" and (.spec.prometheus.remoteWrite | length) == 0' \
+    "${prometheus_empty_remote_write_manifest}" >/dev/null; then
+    echo "The default Prometheus remoteWrite value is not an empty array." >&2
+    exit 1
+fi
+
+helm template monitoring "${chart_dir}" \
+    --set prometheus.install=true \
+    --set-string 'prometheus.remoteWrite[0].name=primary' \
+    --set-string 'prometheus.remoteWrite[0].url=https://remote-write.example/api/v1/write' \
+    >"${prometheus_remote_write_manifest}"
+if ! "${yq_binary}" eval-all -e \
+    'select(.apiVersion == "monitoring.netcracker.com/v1" and .kind == "PlatformMonitoring") |
+    (.spec.prometheus.remoteWrite | tag) == "!!seq" and
+    (.spec.prometheus.remoteWrite | length) == 1 and
+    .spec.prometheus.remoteWrite[0].name == "primary" and
+    .spec.prometheus.remoteWrite[0].url == "https://remote-write.example/api/v1/write"' \
+    "${prometheus_remote_write_manifest}" >/dev/null; then
+    echo "The chart does not preserve a configured Prometheus remoteWrite endpoint." >&2
+    exit 1
+fi
+
 verify_rendered_resource_count "${rendered_manifest}" \
     '.kind == "Job" and
     .metadata.labels."app.kubernetes.io/component" == "etcd-certs-to-secret" and


### PR DESCRIPTION
# What does this PR do?

Renders an empty managed Prometheus `remoteWrite` value as `[]` instead of YAML `null`. Structural Helm checks cover empty and configured remote-write lists.

## Why

The PlatformMonitoring CRD requires `spec.prometheus.remoteWrite` to be an array. A fresh installation with `prometheus.install=true` and the default empty list was rejected by the API server before reconciliation started.

Closes #507.

## How to verify

- Run `bash tools/verify-helm-crds.sh`.
- Run `helm lint charts/qubership-monitoring-operator`.
- Install the chart in Kind with managed Prometheus enabled and `prometheus.remoteWrite=[]`; PlatformMonitoring reaches `Successful=True`, and Prometheus reaches `Available=True`.

## Checklist

- [x] `make generate` is not required because the API did not change.
- [ ] `make test` is blocked in linked worktrees by #510; CI runs the suite from a standard checkout.
- [x] Documentation and CRD updates are not required because the public values contract did not change.
